### PR TITLE
fix: improve automatic detection of binomial taxonomic ranks

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.7.1
 commit = True
 tag = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath("../src/niamoto"))
 project = "niamoto"
 copyright = "2025, Julien Barbe"
 author = "Julien Barbe"
-release = "0.7.0"
+release = "0.7.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "niamoto"
-version = "0.7.0"
+version = "0.7.1"
 description = ""
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/niamoto/__version__.py
+++ b/src/niamoto/__version__.py
@@ -1,3 +1,3 @@
 """Version information for Niamoto."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/src/niamoto/core/components/imports/plots.py
+++ b/src/niamoto/core/components/imports/plots.py
@@ -1294,10 +1294,10 @@ class PlotImporter:
 
         name = str(name).strip()
 
-        # Check if entity already exists
+        # Check if entity already exists with the same parent
         existing = (
             session.query(PlotRef)
-            .filter_by(locality=name, plot_type=level_type)
+            .filter_by(locality=name, plot_type=level_type, parent_id=parent_id)
             .first()
         )
         if existing:

--- a/src/niamoto/core/components/imports/taxons.py
+++ b/src/niamoto/core/components/imports/taxons.py
@@ -96,6 +96,7 @@ class TaxonomyImporter:
             # Extract ranks and column mapping from hierarchy config
             rank_list = []
             new_column_mapping = {}
+            binomial_ranks = set()  # Track which ranks should use binomial naming
 
             for level in hierarchy_config["levels"]:
                 if "name" not in level or "column" not in level:
@@ -105,6 +106,10 @@ class TaxonomyImporter:
                     )
                 rank_list.append(level["name"])
                 new_column_mapping[level["name"]] = level["column"]
+
+                # Check if this rank should use binomial naming
+                if level.get("binomial", False):
+                    binomial_ranks.add(level["name"])
 
             # Add taxon_id and authors if specified
             if "taxon_id_column" in hierarchy_config:
@@ -136,7 +141,7 @@ class TaxonomyImporter:
 
             # Extract taxonomy data
             taxonomy_df = self._extract_taxonomy_from_occurrences(
-                df, column_mapping, ranks
+                df, column_mapping, ranks, binomial_ranks
             )
 
             # Process the taxonomy data and build the hierarchy
@@ -373,7 +378,11 @@ class TaxonomyImporter:
         return imported_count
 
     def _extract_taxonomy_from_occurrences(
-        self, df: pd.DataFrame, column_mapping: Dict[str, str], ranks: Tuple[str, ...]
+        self,
+        df: pd.DataFrame,
+        column_mapping: Dict[str, str],
+        ranks: Tuple[str, ...],
+        binomial_ranks: set = None,
     ) -> pd.DataFrame:
         """
         Extract unique taxonomy entries from occurrences and build complete taxonomy hierarchy,
@@ -383,6 +392,7 @@ class TaxonomyImporter:
             df (pd.DataFrame): DataFrame containing occurrences.
             column_mapping (Dict[str, str]): Mapping between taxonomy fields and occurrence columns.
             ranks (Tuple[str, ...]): Taxonomy ranks to extract.
+            binomial_ranks (set): Set of rank names that should use binomial naming.
 
         Returns:
             pd.DataFrame: DataFrame containing extracted taxonomy data with complete hierarchy.
@@ -485,7 +495,7 @@ class TaxonomyImporter:
             # Store the complete data for this taxon at its lowest rank
             if lowest_rank is not None:
                 full_name = self._build_full_name_generic(
-                    row, column_mapping, rank_values, rank_names
+                    row, column_mapping, rank_values, rank_names, binomial_ranks
                 )
 
                 taxa_data.append(
@@ -608,6 +618,7 @@ class TaxonomyImporter:
         column_mapping: Dict[str, str],
         rank_values: Dict[str, Any],
         rank_names: List[str],
+        binomial_ranks: set = None,
     ) -> str:
         """
         Build a complete taxonomy name from the data of an occurrence row for any hierarchy.
@@ -617,6 +628,7 @@ class TaxonomyImporter:
             column_mapping (Dict[str, str]): Mapping between taxonomy fields and occurrence columns.
             rank_values (Dict[str, Any]): Values for each rank.
             rank_names (List[str]): List of rank names in hierarchical order.
+            binomial_ranks (set): Set of rank names that should use binomial naming.
 
         Returns:
             str: Complete taxonomy name.
@@ -635,28 +647,15 @@ class TaxonomyImporter:
         # Get the lowest rank value
         current_value = str(rank_values[lowest_rank]).strip()
 
-        # Only build binomial/trinomial names for species-level ranks and below
-        # Common species-level ranks: species, subspecies, variety, form, infra
-        species_level_ranks = [
-            "species",
-            "subspecies",
-            "variety",
-            "form",
-            "infra",
-            "subsp",
-            "var",
-            "f",
-        ]
-
-        # Check if this is a species-level rank (or a custom rank that comes after genus)
-        is_species_level = False
-        if lowest_rank.lower() in species_level_ranks:
+        # Determine if binomial naming should be used
+        # First check explicit configuration, then use auto-detection
+        if binomial_ranks and lowest_rank in binomial_ranks:
             is_species_level = True
-        elif (
-            lowest_rank_idx >= 2
-        ):  # If it's at least the third rank (after family, genus)
-            # For custom hierarchies, assume ranks after the second are species-level
-            is_species_level = True
+        else:
+            # Fall back to auto-detection if not explicitly configured
+            is_species_level = self._is_species_level_rank(
+                lowest_rank, lowest_rank_idx, rank_names
+            )
 
         if is_species_level and lowest_rank_idx >= 1:
             # Get the genus (parent rank)
@@ -676,6 +675,59 @@ class TaxonomyImporter:
         else:
             # For family, genus, and other high-level ranks, just return the name
             return current_value
+
+    def _is_species_level_rank(
+        self, rank_name: str, rank_idx: int, rank_names: List[str]
+    ) -> bool:
+        """
+        Determine if a rank should use binomial naming based on its name and position.
+
+        Args:
+            rank_name: The name of the rank
+            rank_idx: The index of the rank in the hierarchy
+            rank_names: The list of all rank names in hierarchical order
+
+        Returns:
+            bool: True if binomial naming should be used, False otherwise
+        """
+        # Common patterns for species-level ranks
+        species_keywords = [
+            "species",
+            "sp",
+            "subspecies",
+            "subsp",
+            "ssp",
+            "variety",
+            "var",
+            "form",
+            "forma",
+            "f",
+            "infra",
+            "infraspecific",
+        ]
+
+        # Check if the rank name contains species-level keywords
+        rank_lower = rank_name.lower()
+        for keyword in species_keywords:
+            if keyword in rank_lower or rank_lower == keyword:
+                return True
+
+        # For custom hierarchies, use positional logic:
+        # If we have at least 3 levels and this is the 3rd or later,
+        # AND the previous rank could be a genus (doesn't contain species keywords)
+        if rank_idx >= 2 and len(rank_names) >= 3:
+            # Check if the parent rank is likely a genus (not a species-level rank itself)
+            parent_rank = rank_names[rank_idx - 1]
+            parent_is_genus_like = not any(
+                keyword in parent_rank.lower() for keyword in species_keywords
+            )
+
+            # If parent looks like genus and current doesn't explicitly say otherwise,
+            # treat as species-level
+            if parent_is_genus_like:
+                return True
+
+        return False
 
     def _build_full_name(self, row: pd.Series, column_mapping: Dict[str, str]) -> str:
         """

--- a/uv.lock
+++ b/uv.lock
@@ -974,7 +974,7 @@ wheels = [
 
 [[package]]
 name = "niamoto"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Improved taxonomy import system to correctly handle occurrences identified at genus level
- Added intelligent automatic detection of ranks requiring binomial naming
- Support for optional configuration to force binomial naming on specific ranks

## Problem Solved
Some occurrences in the CSV file are identified only at genus level (e.g., "Beilschmiedia", "Diospyros"), and the system was incorrectly generating binomial names for these genera.

## Implemented Solution
1. **Automatic Detection**: The system now automatically detects if a rank should use binomial naming based on:
   - Keywords in the rank name (species, subspecies, variety, form, infra, etc.)
   - Hierarchical position (3rd rank or later with a genus-like parent)

2. **Optional Configuration**: Ability to add `binomial: true` in configuration to force binomial naming on specific ranks

## Changes
- Added `_is_species_level_rank()` method for automatic detection
- Support for `binomial` parameter in YAML configuration
- Modified `_build_full_name_generic()` to use this logic

## Test plan
- [x] Verify genera without species are correctly imported (e.g., "Beilschmiedia")
- [x] Verify species still use binomial naming
- [x] Test with and without `binomial` parameter in configuration
- [x] Run full import on test-instance dataset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved configurability and accuracy of binomial naming for taxonomy imports, allowing explicit control and better heuristics for species-level naming.

* **Bug Fixes**
  * Enhanced uniqueness checks for hierarchical entities to prevent false positives when entities share the same name and type but have different parent entities.

* **Chores**
  * Updated project version to 0.7.1 across configuration and documentation files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->