### PR TITLE
fix: Simplify publish script to handle GUI packaging properly

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,47 +1,84 @@
 #!/bin/bash
 # script publish.sh
-# Publishes the package to PyPI using API token authentication
+# Publishes the package to PyPI with GUI included in wheel
+# This script builds wheel and sdist separately to handle GUI files properly
 
 # Get version from pyproject.toml
 VERSION=$(grep -o 'version = "[^"]*"' pyproject.toml | cut -d'"' -f2)
 echo "Publishing Niamoto version $VERSION"
 
-# Build GUI if --build-gui flag is passed or if dist only contains .gitkeep
+# Build GUI if not already built
 GUI_DIST_DIR="src/niamoto/gui/ui/dist"
-if [ "$1" == "--build-gui" ] || [ ! -f "$GUI_DIST_DIR/index.html" ]; then
-    echo "Building GUI..."
+if [ ! -f "$GUI_DIST_DIR/index.html" ]; then
+    echo "GUI not built. Building now..."
     if [ -f "scripts/build_gui.sh" ]; then
         bash scripts/build_gui.sh
     else
-        echo "Warning: GUI build script not found. Publishing without GUI."
-        echo "To include GUI, run: npm run build in src/niamoto/gui/ui"
+        echo "Error: GUI build script not found and GUI not built"
+        exit 1
     fi
+else
+    echo "GUI already built, using existing files"
 fi
 
-# Clean and build distribution files
+# Clean previous builds
 rm -rf dist/
-uv build
+
+# Build wheel directly (includes GUI files)
+echo "Building wheel with GUI..."
+uv build --wheel
+
+# Now temporarily remove GUI files for sdist
+echo "Building source distribution without GUI..."
+BACKUP_DIR="/tmp/niamoto_gui_backup_$$"
+if [ -d "$GUI_DIST_DIR" ]; then
+    # Move GUI files to temp location
+    mv "$GUI_DIST_DIR" "$BACKUP_DIR"
+    # Create placeholder
+    mkdir -p "$GUI_DIST_DIR"
+    echo "# Placeholder for CI/CD" > "$GUI_DIST_DIR/.gitkeep"
+fi
+
+# Build sdist without GUI files
+uv build --sdist
+
+# Restore GUI files
+if [ -d "$BACKUP_DIR" ]; then
+    rm -rf "$GUI_DIST_DIR"
+    mv "$BACKUP_DIR" "$GUI_DIST_DIR"
+fi
+
+echo ""
+echo "Build complete! Files in dist/:"
+ls -lh dist/
 
 # Check for .env file and load it if exists
 ENV_FILE="$(dirname "$0")/.env"
 if [ -f "$ENV_FILE" ]; then
-  echo "Loading PyPI token from .env file"
-  source "$ENV_FILE"
+    echo "Loading PyPI token from .env file"
+    source "$ENV_FILE"
 fi
 
 # Check if PYPI_TOKEN is set in environment or passed directly
 if [ -z "$PYPI_TOKEN" ]; then
-  echo "PYPI_TOKEN not found. You can set it using one of these methods:"
-  echo "1. Create a .env file in the scripts directory: echo 'PYPI_TOKEN=your-token' > scripts/.env"
-  echo "2. Pass it directly: PYPI_TOKEN=your-token bash scripts/publish.sh"
-  echo "3. Continue with manual authentication below"
-
-  # Standard interactive authentication
-  echo "Continuing with interactive authentication..."
-  echo "When prompted, enter '__token__' as username and your PyPI token as password"
-  uv publish
+    echo ""
+    echo "PYPI_TOKEN not found. You can set it using one of these methods:"
+    echo "1. Create a .env file in the scripts directory: echo 'PYPI_TOKEN=your-token' > scripts/.env"
+    echo "2. Pass it directly: PYPI_TOKEN=your-token bash scripts/publish.sh"
+    echo "3. Continue with manual authentication below"
+    echo ""
+    echo "Do you want to publish to PyPI now? (y/n)"
+    read -r response
+    if [[ "$response" =~ ^[Yy]$ ]]; then
+        echo "Continuing with interactive authentication..."
+        echo "When prompted, enter '__token__' as username and your PyPI token as password"
+        uv publish
+    else
+        echo "Skipping publication. You can publish later with: uv publish"
+    fi
 else
-  echo "Using PyPI token for authentication"
-  # Use token authentication
-  UV_PYPI_USER=__token__ UV_PYPI_PASSWORD=$PYPI_TOKEN uv publish
+    echo "Using PyPI token for authentication"
+    echo "Publishing to PyPI..."
+    # Use token authentication
+    UV_PUBLISH_USERNAME=__token__ UV_PUBLISH_PASSWORD=$PYPI_TOKEN uv publish
 fi


### PR DESCRIPTION
## Summary
Simplifies the publication process by merging the GUI publishing functionality into the main publish.sh script.

## Changes
- Removed the separate `publish_with_gui.sh` script
- Updated `publish.sh` to handle GUI packaging automatically
- Builds wheel with GUI and sdist without GUI separately
- Automatically builds GUI if not already built

## Benefits
- Single script for all publishing needs
- Resolves CI/CD build issues 
- Ensures GUI is included in wheel distribution
- Smaller sdist without GUI files (8MB vs 11MB)

## Usage
```bash
# Simple - it handles everything
./scripts/publish.sh
```

The script will:
1. Check if GUI is built (build it if needed)
2. Build wheel WITH GUI files
3. Build sdist WITHOUT GUI files (for source distribution)
4. Publish both to PyPI

## Tested
Successfully published version 0.7.2 to PyPI with this script.