### PR TITLE
feat: release automation infrastructure

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -18,3 +18,7 @@ replace = __version__ = "{new_version}"
 [bumpversion:file:src-tauri/tauri.conf.json]
 search = "version": "{current_version}"
 replace = "version": "{new_version}"
+
+[bumpversion:file:src-tauri/Cargo.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -1,0 +1,111 @@
+name: Build Tauri Desktop
+
+on:
+  workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Attach bundles to existing GitHub Release'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build-tauri:
+    name: Build ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            name: macOS-arm64
+            target: aarch64-apple-darwin
+            binary_suffix: ''
+          - os: ubuntu-22.04
+            name: Linux-x86_64
+            target: x86_64-unknown-linux-gnu
+            binary_suffix: ''
+          - os: windows-latest
+            name: Windows-x86_64
+            target: x86_64-pc-windows-msvc
+            binary_suffix: '.exe'
+
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # --- System dependencies ---
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev libwebkit2gtk-4.1-dev \
+            libappindicator3-dev librsvg2-dev patchelf \
+            gdal-bin libgdal-dev libproj-dev
+
+      # --- Python sidecar ---
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install Python package
+        run: |
+          pip install uv
+          uv venv
+          uv pip install -e .
+          uv pip install pyinstaller
+
+      - name: Build Python binary (PyInstaller)
+        run: uv run pyinstaller build_scripts/niamoto.spec --clean --noconfirm
+
+      - name: Place sidecar binary (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          mkdir -p src-tauri/bin
+          cp dist/niamoto src-tauri/bin/niamoto-${{ matrix.target }}
+
+      - name: Place sidecar binary (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path src-tauri/bin
+          Copy-Item dist/niamoto.exe src-tauri/bin/niamoto-${{ matrix.target }}.exe
+
+      # --- Frontend ---
+      - name: Enable pnpm
+        run: corepack enable
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+          cache-dependency-path: src/niamoto/gui/ui/pnpm-lock.yaml
+
+      - name: Install frontend deps
+        run: cd src/niamoto/gui/ui && pnpm install --frozen-lockfile
+
+      # --- Rust + Tauri ---
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Tauri
+        uses: tauri-apps/tauri-action@v0
+        with:
+          projectPath: src-tauri
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Tauri bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: tauri-${{ matrix.name }}
+          path: |
+            src-tauri/target/release/bundle/**/*.dmg
+            src-tauri/target/release/bundle/**/*.app
+            src-tauri/target/release/bundle/**/*.deb
+            src-tauri/target/release/bundle/**/*.AppImage
+            src-tauri/target/release/bundle/**/*.msi
+            src-tauri/target/release/bundle/**/*.exe
+          retention-days: 7

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,96 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-gui:
+    name: Build React UI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+          cache-dependency-path: src/niamoto/gui/ui/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd src/niamoto/gui/ui && pnpm install --frozen-lockfile
+
+      - name: Build React
+        run: cd src/niamoto/gui/ui && pnpm run build
+
+      - name: Upload GUI build
+        uses: actions/upload-artifact@v7
+        with:
+          name: gui-dist
+          path: src/niamoto/gui/ui/dist/
+          retention-days: 1
+
+  build:
+    name: Build distributions
+    needs: build-gui
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Download GUI build
+        uses: actions/download-artifact@v8
+        with:
+          name: gui-dist
+          path: src/niamoto/gui/ui/dist/
+
+      - name: Enable GUI in wheel build
+        run: |
+          sed -i 's/# "src\/niamoto\/gui\/ui\/dist"/"src\/niamoto\/gui\/ui\/dist"/' pyproject.toml
+
+      - name: Install build tools
+        run: pip install uv
+
+      - name: Build wheel (with GUI)
+        run: uv build --wheel
+
+      - name: Restore pyproject.toml for sdist
+        run: git checkout pyproject.toml
+
+      - name: Build sdist (without GUI)
+        run: uv build --sdist
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # With Trusted Publishers (OIDC), no token needed.
+        # Fallback: uncomment below and add PYPI_TOKEN to GitHub secrets
+        # with:
+        #   password: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,147 +5,470 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [v0.9.0] - 2026-03-23
 
-### Added
-- **ML Column Classification (Phase 1-3)**: Generic multi-model column detection system
-  - 3-branch classifier architecture: header (TF-IDF + LogReg), values (HistGradientBoosting), fusion (calibrated LogReg)
-  - Alias registry YAML with ~25 ecological concepts × 5-8 languages (EN/FR/ES/PT/DE/ID/DwC)
-  - `ColumnSemanticProfile` with role/concept/affordances ontology
-  - Affordance-based transformer→widget matching (8 transformers profiled)
-  - Dataset Pattern Detector: 6 patterns (occurrence, forest, spatial, checklist, trait, temporal)
-  - Anomaly rules: 12 domain validators (lat/lon, DBH, pH, altitude, depth, etc.)
-  - Evaluation harness with GroupKFold, geographic/linguistic holdouts, ablations
-  - Gold set: 2231 columns (1635 gold + 596 synthetic, 88 sources, 6 continents)
-  - Autoresearch optimization loops: header 0.37→0.56, values 0.29→0.35, fusion 0.97 macro-F1
+### Features
 
-### Changed
-- Replaced old `MLColumnDetector` (21 features, RF) with alias registry + 3-branch `ColumnClassifier`
-- FK heuristic simplified, specific ID type detection delegated to alias registry
-- Models loaded via plain `joblib.load()` (lazy, on first `classify()` call)
+- Integrate ML acquisition wave and retraining results
+- Replace synthetic anonymous holdout with diversified real columns
+- Retrained models on enriched gold set (2525 cols)
+- Add niamoto-nc to gold set, fix basal_area merge
+- Expand alias registry — 13 new concepts, 76.6% concept (+5.3)
+- Multi-dataset eval suite — 418 cols, 7 datasets, 71% concept
+- Full instance evaluation with annotations — 57 cols, alias 25% → ML 46% concept
+- Retrain all models with cross-rank reciprocity features — ProductScore 79.25 → 80.04 (+0.79)
+- Add fusion surrogate autoresearch runner
+- Add product-oriented evaluation and surrogate fusion loop
+- Complete Phase 3 — profiles, affordances, patterns, anomalies
+- Concept taxonomy, enriched data, coarsened training (2231 cols)
+- Add gold set builder, training scripts, and CLI metric
+- Add alias registry, ml_mode API, and evaluation harness
 
-### Removed
-- Old pattern matching code in profiler (superseded by alias registry)
+### Bug Fixes
+
+- Correct silver.yml ground-truth annotations for afrique dataset
+- Broaden pre-commit large-file exclusion to cover ml/models/*.joblib
+- Raise ML confidence threshold to 0.6 to prevent false positives
+- Clean up stale paths and packaging after ml/ centralization
+- Restore ml autoresearch and packaging entrypoints
+- Skip pre-commit hooks in autoresearch runner commits
+- Replace codex with claude cli in surrogate runner
+- Defer stack validation in surrogate runner, add scope filter
+- Harden surrogate autoresearch prompt
+- Defer stack baseline in surrogate runner
+- Address gpt-5.4 review — ship models, fix hierarchy ID, anonymous inference, coordinates
+- Address codex review — align identifier namespace, geometry affordances, drop rapidfuzz
+- Address P1 review findings — remove dead code and unsafe deserialization
+
+### Refactoring
+
+- Centralize offline ML workspace under ml
+- Simplify FK heuristic, delegate specific id types to alias registry
+- Address P3 review findings
+- Address P2 review findings
+- Replace old pattern matching with alias registry, remove old MLColumnDetector
+
+### Performance
+
+- Batch fusion features in evaluate.py — ProductScore 14h → 42min
+- Batch fusion feature extraction — training 5h → 15min, identical results
+
+### Documentation
+
+- Update CHANGELOG for v0.9.0 release
+- Fix CodeRabbit review findings — paths and changelog accuracy
+- Reorganize ml detection knowledge base
+- Add pertinence audit plan and update autoresearch programmes
+- Add standards-based dataset acquisition plan
+- Rename NiamotoOfflineScore → GlobalScore, remove CSV mention
+- Add info tooltips to dashboard hero stat cards
+- Update error patterns with fix status after session improvements
+- Add workflow schema and improvement timeline to dashboard
+- Add training & evaluation guide — complete workflow documentation
+- Update dashboard and experiment doc with V5 results (77.5% concept)
+- Rewrite ML detection dashboard with current data and new sections
+- Remove archived obsolete documentation
+- Translate all ML detection docs to English, rewrite index, fix cross-references
+- Archive obsolete files and reorganize documentation structure
+- Log retraining, ProductScore 80.04, batch optimization 20x, instance eval
+- Log session 2026-03-19 — runner fixes, cross-rank gain, plateau
+- Add integration status report, fix restore_paths for untracked files
+- Rewrite overview for botanist audience
+- Update roadmap with enriched dataset results
+
+### Chores
+
+- Add ablation runner and tune header convergence
+- Update uv.lock for 0.8.1
+
+### Other Changes
+
+- Autoresearch(values): macro-F1 0.3522 → 0.3527 (+0.05 pts)
+- Autoresearch(values): macro-F1 0.3433 → 0.3522 (+0.89 pts)
+- Autoresearch(values): macro-F1 0.3403 → 0.3433 (+0.30 pts)
+- Autoresearch(values): macro-F1 0.3370 → 0.3403 (+0.33 pts)
+- Autoresearch(values): macro-F1 0.2877 → 0.3068 (+1.91 pts)
+- Autoresearch(values): macro-F1 0.3063 → 0.3257 (+1.9 pts)
+- Autoresearch(values): macro-F1 0.3005 → 0.3063 (+0.6 pts)
+- Autoresearch(values): macro-F1 0.2877 → 0.3005 (+1.3 pts)
+- Autoresearch(header): macro-F1 0.5640 → 0.5641 (+0.01 pts)
+- Autoresearch(header): macro-F1 0.5591 → 0.5640 (+0.49 pts)
+- Autoresearch(header): macro-F1 0.5529 → 0.5591 (+0.62 pts)
+- Autoresearch(header): macro-F1 0.5497 → 0.5529 (+0.32 pts)
+- Autoresearch(header): macro-F1 0.5470 → 0.5497 (+0.27 pts)
+- Autoresearch(header): macro-F1 0.5383 → 0.5470 (+0.87 pts)
+- Autoresearch(header): macro-F1 0.5375 → 0.5383 (+0.08 pts)
+- Autoresearch(header): macro-F1 0.5370 → 0.5375 (+0.05 pts)
+- Autoresearch(header): macro-F1 0.5283 → 0.5370 (+0.87 pts)
+- Autoresearch(header): macro-F1 0.4937 → 0.5283 (+3.46 pts)
+- Autoresearch(header): macro-F1 0.4931 → 0.4937 (+0.06 pts)
+- Autoresearch(header): macro-F1 0.4864 → 0.4931 (+0.67 pts)
+- Autoresearch(header): macro-F1 0.4763 → 0.4864 (+1.01 pts)
+- Autoresearch(header): macro-F1 0.4455 → 0.4763 (+3.08 pts)
+- Autoresearch(header): macro-F1 0.3658 → 0.4455 (+7.97 pts)
+
+## [v0.8.1] - 2026-03-15
+
+### Bug Fixes
+
+- Add monaco-editor types as dev dependency
+
+### Refactoring
+
+- Declarative registries, POST inline, smart entity selection (#55)
+
+## [v0.8.0] - 2026-03-14
+
+### Features
+
+- Add multi-platform deployment from GUI
+- Add sidebar layout to Data, Groups and Publish modules
+- Add pipeline status hooks, home page and staleness banner
+- Simplify navigation, fix multi-lang export and map rendering
+- Refactor footer as category-based sections with internal/external links
+- Create niamoto-subset instance from niamoto-nc for fast testing
+- Centre de notifications connecté aux jobs du pipeline
+- Bouton transform dans GroupPanel + checkbox composite dans Build
+- Ajouter group_by, endpoints active/last-run et job composite transform→export
+- Ajouter JobFileStore + fix os.chdir() thread-unsafe
+- Add shimmer loading skeleton with widget-type icons
+- Add Plotly bundle splitting (core 1.3MB, maps 2.2MB)
+- Migrate all preview components to unified engine and delete legacy queue
+- Wire preview engine invalidation and migrate recipes (Phase 4)
+- Add usePreviewFrame hook and shared preview components (Phase 3)
+- Add unified preview engine (Phase 1)
+- Add combined widget analysis previews
+- Centralize table resolver and transform config models
+- Full offline support for desktop application
+- Enrich raster_stats and land_use with layer-select UI hints
+- Add geographic layers API and LayerSelectField widget
+- Add Phase 2.1 form widgets for transform configuration
+- Add KeyValuePairsField and TagsField widgets with auto-detection
+- Enrich Pydantic models with UI hints and fix Select.Item bug
+- Use native macOS titlebar overlay instead of custom traffic lights
+- Add multilingual support and i18n infrastructure
+- Add MapRenderer service and fix layout preview issues
+- Refactor index config with side panel editor and reusable preview
+- Improve site preview navigation and widget suggestions
+- Complete i18n migration for all UI components
+- Enhance site builder with improved navigation and group preview
+- Add x_label and y_label quick edit fields for axis customization
+- Implement Option A hybrid layout with improved widget modal
+- Add multi-field pattern detection for combined widgets
+- Add drag-and-drop widget reordering and layout.order support
+- Add specialized parameter editors and preview service
+- Add unified widget recipe editor with wizard interface
+- Enhance relation detection and support for class_object_field_aggregator
+- Add index generator configuration and widget management
+- Enhance desktop app with welcome screen, site config UI and layout editor
+- Add advanced theme system with typography, shapes, and effects
+- Replace bootstrap with intelligent widget suggestion system
+- Integrate Tauri for desktop application support
+
+### Bug Fixes
+
+- Remove obsolete deploy CLI tests and fix SyntaxWarning
+- Comprehensive i18n audit — replace all French fallbacks with English, fix namespace issues and add missing translation keys
+- Add fixed seed to ML detector tests for cross-version reproducibility
+- Remove duplicate legacy preview route that shadowed templates router
+- Address PR #54 review comments (CI, build scripts, docs)
+- Datetime serialization in job store and obsolete preview mount test
+- Prevent duplicate toasts and wrong group name on transform completion
+- Supprimer read_only=True des connexions DuckDB API
+- Codex review #3 — conditional polling, strict types, i18n timeAgo
+- Corrections revue Codex #2 — sécurité, i18n, robustesse
+- Extraire les chaînes FR hardcodées vers i18n (sources + publish)
+- Corrections revue Codex — filtrage job_type, progression monotone, polling reprise
+- Résoudre le montage preview et les chemins relatifs export
+- Resolve full export pipeline for taxons, plots, and shapes
+- Ajouter skipif pour les tests dépendant des instances locales
+- Corriger la génération de config des suggestions et les tests cassés
+- Add html.escape() to all widget error messages and data interpolations
+- Add padding to info_grid widget container
+- Refresh button now bypasses browser cache and shows shimmer
+- Categorical_distribution type coercion for YAML string categories
+- Rewrite _render_entity_map and pass is_map=True to Plotly
+- Series_extractor bar_plot field name mismatch and missing param forwarding
+- Stabilize widget previews and shape scalar gauges
+- Correct widget previews for entity and class_object sources
+- Add minimal Tailwind classes and CSS chevron for navigation preview
+- Remove CDN dependencies (Tailwind, Font Awesome) from previews
+- Force iframe preview refresh after widget reorder
+- Fix drag & drop snap-back and refresh layout after reorder
+- Make request optional in preview_template for direct call from layout.py
+- Exclude FastAPI-injected request parameter from signature test
+- Fix TypeScript errors and preview refresh
+- Finalize analysis transformer output and formatting
+- Stabilize config scaffolding and import config access
+- Formatting and remaining test updates for v1 config contract
+- Handle inline content_markdown in static pages
+- Update test assertions and mocks for recent changes
+- Ensure gauge widget is proposed for all numeric columns
+- Improve relation reference_key detection
+- Handle identical values in distribution preview and fix binary counter
+- Improve widget suggestions and fix geometry serialization errors
+- Use working directory context for Config in GUI API
+- Update tests for absolute database path and refine numeric/categorical detection
+
+### Updates
+
+- Ci: upgrade GitHub Actions to Node.js 24 compatible versions
+
+### Refactoring
+
+- Migrate deployers from services to plugins, add GUI deploy API with health check and unpublish
+- Flatten sidebar navigation and remove Labs/Tools sections
+- Delegate to TransformerService with shared code path
+- Intégrer JobFileStore dans les routers transform et export
+- Finalize preview engine — dead code removal, security hardening, ETag optimization
+- Consolidate HTML wrappers, remove dead Plotly bundle, fix review findings
+- Extract preview_utils and decouple engine from PreviewService
+- Migrate hooks to React Query + debounce
+- Optimize widget preview system performance
+- Migrate npm to pnpm and update build scripts
+- Update EntityKind types, config generator and components
+- Harden routers, normalize YAML None values, migrate to table resolver
+- Rename Index tab to Liste for better UX
+- Reorganize components directory structure
+- Reorganize routes and consolidate API structure
+- Cleanup legacy code and reorganize components
+- Separate data loading from transformation logic
+
+### Documentation
+
+- Alléger le plan transform trigger + corrections revue Codex
+- Ajouter les plans shapes config et transform trigger + jobs robustes
+- Add preview architecture, API reference, and widget thumbnail guide
+- Mark all acceptance criteria as validated
+- Add architecture docs, v1 release plan and config contract
+- Rewrite plugin dev guide with modern Pydantic patterns + update plan
+- Add Phase 3.3 user documentation for transform widgets
+- Add Phase 3.2 config simplification analysis (6 axes identified)
+- Update plan - mark Phase 2.5 layers as completed
+
+### Tests
+
+- Add preview engine tests and update layout tests
+- Add e2e, data explorer, stats and service tests
+- Add Phase 3.1 end-to-end tests for GUI config generation (30 tests)
+- Add Phase 1.3 transform config validation tests (56 tests)
+
+### Style
+
+- Replace Rocket icon with Send and Menu with PanelLeft
+- Redesign command palette with grouped layout and descriptions
+
+### Chores
+
+- Sync tauri version to 0.7.5 and add it to bumpversion config
+- Update npm dependencies to fix security vulnerabilities
+
+## [v0.7.5] - 2025-11-18
+
+### Features
+
+- Add PyInstaller support and resource cascade system
+
+### Bug Fixes
+
+- Correct PyInstaller settings to prevent numpy and DLL corruption
+- Replace Unicode arrows and bullets with ASCII, fix run command description
+- Replace all Unicode emojis with cross-platform emoji() function
+- Replace Unicode characters with ASCII-only for Windows compatibility
+- Replace Unicode characters with ASCII in spec file
+- Commit package-lock.json for reproducible builds
+- Actually check directory emptiness before blocking init
+- Improve init command path handling and error messages
+- Restore working directory after init command
+- Handle Windows paths in project name extraction
+- Correct project path derivation in plugins command
+- Remove hard dependency on uv tool
+- Flatten Windows zip structure for easier extraction
+
+### Performance
+
+- Reduce binary size by 43% through dependency optimization
+
+### Documentation
+
+- Add comprehensive git tag management commands
+
+### Other Changes
+
+- Ci: remove macOS Intel build to save GitHub Actions quota
+
+## [v0.7.4-test] - 2025-11-15
+
+### Bug Fixes
+
+- Correction de 13 bugs dans les plugins transformers et l'API smart_config
+- Preserve large integer ID precision and load group_by dynamically
+
+### Updates
+
+- Build: upgrade minimum Python version from 3.10 to 3.11
+
+### Tests
+
+- Amélioration de la couverture de tests de 60% à 68%
+- Fix test assertions and add auxiliary file cleanup
+
+### Chores
+
+- Move Claude Code config files to gitignore
+
+## [v0.7.4] - 2025-11-14
+
+### Features
+
+- Remove hardcoded table references in showcase metrics
+- Remove hardcoded entity references in data explorer and showcase
+- Complete EntityRegistry v2 migration for stats and entities
+- Add development tooling with instance context management
+- Add intelligent onboarding wizard with auto-configuration
+- Add transform-source-select widget with group context
+- Migrate 11 transformers to entity-select widget
+- Add dynamic entity-select widget and update config templates
+- Migrate aggregation transformers to EntityRegistry
+- Migrate 3 distribution transformers to EntityRegistry
+- Migrate remaining 3 class_objects transformers to EntityRegistry
+- Migrate categories_extractor and series_extractor class_objects transformers to EntityRegistry
+- Migrate loaders to EntityRegistry and create refactoring tracking system
+- Add environment variable substitution and plugin config validation
+- Add partners section to TeamSection component with logos and descriptions
+- Add PerspectivesSection component and integrate into showcase page fix: update Rich version in StackTechSection fix: include 'perspectives' in showcase store sections
+- Implement pipeline management with tabs and shared state
+- Add Cloudflare deployment functionality and integrate into the GUI
+- Add API demo component and integrate into showcase page
+- Add exports structure API endpoint and update UI components for directory visualization
+- Add YAML configuration editor and backup functionality
+- Update API documentation page and navigation structure
+- Add Plotly.js and react-plotly.js for data visualization
+- Update GUI documentation and improve language switcher component
+- Implement enrichment preview functionality in Data Explorer
+- Add package.json to repo for Docker builds
+- Enhance showcase components with improved YAML configuration display and updated use case statistics
+- Implement interactive showcase pages with real data pipeline integration
+- Expose plugin param schemas for dynamic gui config
+- Implement unified pipeline editor with ReactFlow
+- Improve Transform interface and add pipeline specifications
+- Implement hierarchical navigation and transform pipeline interface
+- Add SQLite performance optimizations
+- Update CLAUDE.md for development guidelines and commands; update permissions in settings.local.json; refine error handling in bar_plot and donut_chart widgets
+
+### Bug Fixes
+
+- Preserve large integer IDs precision in index generation
+- Fix pytest collection and test database artifacts
+- Update instance initialization to EntityRegistry v2 format
+- Improve fallback logic for displaying configuration path or file in ImportDemo component
+- Update file count logic to handle edge cases and reorder sections in showcase store
+- Resolve CI/CD build issues with GUI dist directory
+- Restore .gitkeep file for CI/CD builds
+
+### Improvements
+
+- Refactor code structure for improved readability and maintainability
+
+### Refactoring
+
+- Prepare EntityRegistry v2 migration
+
+### Documentation
+
+- Reorganize and fix Sphinx documentation structure
+- Reorganize documentation structure and add ML detection system
+
+### Chores
+
+- Upgrade all dependencies to latest versions
+- Remove old pipeline editor and dead import code
+
+## [v0.7.3] - 2025-08-06
+
+### Features
+
+- Enhance ShapeProcessor to support group_id configuration
+- Update documentation and configuration for multiple data sources
+- Enhance StatsLoader to support dynamic key field lookup
+
+### Bug Fixes
+
+- Update Tropicos API name in enrichment configuration
+- Improve API enrichment field translations
+- Simplify publish script to handle GUI packaging properly
+- Ensure GUI dist directory exists for CI/CD builds
+- Resolve CI/CD build issue with GUI dist directory
+- Correct caching logic in api_taxonomy_enricher
+
+## [v0.7.2] - 2025-08-06
+
+### Features
+
+- Enhance API enrichment with chained requests and improve GUI packaging
+
+## [v0.7.1] - 2025-08-05
+
+### Features
+
+- Add support for binomial naming in TaxonomyImporter
+- Enhance taxonomy name generation logic in TaxonomyImporter
+
+### Bug Fixes
+
+- Refine entity existence check in PlotImporter
+
+### Chores
+
+- Update CHANGELOG for version 0.7.0 release
 
 ## [v0.7.0] - 2025-07-31
 
-### Added
-- **GUI (Graphical User Interface)**: Complete visual configuration interface for Niamoto
-  - Modern web interface built with React 19, TypeScript, Vite, and Tailwind CSS v4
-  - Multi-step import wizard with real-time validation and progress tracking
-  - Drag-and-drop file upload supporting CSV, Excel, JSON, GeoJSON, and Shapefile formats
-  - Interactive column mapping and data transformation configuration
-  - Hierarchical taxonomy editor with visual drag-and-drop functionality
-  - Internationalization support (French/English) with language switcher
-  - FastAPI backend serving both REST API endpoints and static React build
-  - Comprehensive API endpoints for configuration management, file operations, and imports
-  - Faceted spinner loading indicator and enhanced UI components
-- **GUI CLI integration**: Enhanced `niamoto init` command behavior
-  - GUI launches automatically when creating a new project: `niamoto init my-project`
-  - GUI no longer launches by default for simple `niamoto init`
-  - New `--gui` flag to explicitly launch GUI: `niamoto init --gui`
-  - `niamoto gui` command to launch the configuration interface at any time
-- **Simplified CLI help**: Reorganized command help for better user experience
-  - New "Quick Start" section with 3 essential steps
-  - "Common Workflows" section with practical usage scenarios
-  - Cleaner command grouping: Setup, Pipeline, Analysis, Deployment
-  - GUI prominently featured in the workflow
-- **Project naming support**: `niamoto init [project-name]` now accepts an optional project name
-  - Creates a new directory with the project name if provided
-  - Prompts for confirmation when initializing in the current directory
-  - Prevents initialization in existing project directories
-- **Enhanced project metadata**: `config.yml` now includes a `project` section with:
-  - `name`: Project name (customizable during init)
-  - `version`: Project version (default: 1.0.0)
-  - `created_at`: Timestamp of project creation
-  - `niamoto_version`: Version of Niamoto used to create the project
-- **Dynamic browser title**: GUI now displays "Niamoto - [Project Name]" in the browser tab
-  - New API endpoint `/api/config/project` to retrieve project information
-  - React hook `useProjectInfo` for accessing project metadata
-- **Version tracking**: Added `__version__.py` module for consistent version management
-- **Hierarchical data extraction for geospatial_extractor plugin**:
-  - New `extract_children` parameter to extract leaf entities from hierarchical structures
-  - New `hierarchy_config` parameter for generic hierarchical extraction:
-    - `type_field`: Field identifying entity type (e.g., "plot_type")
-    - `leaf_type`: Value identifying leaf entities (e.g., "plot")
-    - `left_field`/`right_field`: Fields for nested set model (default: "lft"/"rght")
-  - Enables extraction of individual plots from hierarchical levels (country, method, etc.)
-  - Maintains backward compatibility with existing configurations
-- **Interactive map improvements**:
-  - Added support for MultiPoint geometries in map visualizations
-  - Fixed hover display to show individual entity names instead of parent node names
-  - Improved automatic zoom calculation with better margins:
-    - Added 5% margin around data bounds to prevent edge clipping
-    - Increased zoom buffer from 0.5 to 1.0 for better visibility
-  - Fixed map centering to use actual data bounds instead of hardcoded coordinates
-- **Shape ID generation**: Shape IDs are now generated using the format `{type}_{id}`
-  - The `type` comes from the shape configuration in `import.yml` (e.g., "grid", "countries")
-  - The `id` comes from the specified `id_field` in the shapefile
-  - Examples: `grid_1`, `countries_120000`, `countries_580000`
-  - This format ensures unique IDs across different shape types and enables proper matching with statistics files
-- **Hierarchical shape support**: Shapes now support hierarchical structures similar to plots
-  - Added fields to `ShapeRef` model: `parent_id`, `lft`, `rght`, `level`, `shape_type`
-  - Automatic creation of parent entries for each shape type (e.g., "countries", "grid" as parents)
-  - Parent shapes aggregate geometries from all their children using GeometryCollection
-  - Enables navigation hierarchy: click on a shape type to see all shapes of that type on one map
-  - Shape types can now have their own detail pages with aggregated maps
-- **Shape processor enhancement**: Modified to preserve individual geometries in collections
-  - GeometryCollections now render each shape individually instead of merging them
-  - Maintains visual separation between shapes while grouping them logically
-  - Better visualization for hierarchical shape data
-- **Shape extra_data standardization**: Added `entity_type` field to shape imports
-  - Shapes now include `entity_type` in extra_data like plots and taxons
-  - Parent type entries have `entity_type: "type"` and `auto_generated: true`
-  - Individual shapes have `entity_type: "shape"` and `auto_generated: false`
-  - Enables consistent entity type identification across all reference models
-- **Interactive map improvements**: Updated map styles and added Mapbox token support
-  - Corrected available map styles to match current Plotly.js capabilities
-  - Added `mapbox_access_token` parameter for premium map styles (satellite, outdoors, etc.)
-  - Free styles: 'open-street-map', 'carto-positron', 'carto-darkmatter', 'carto-voyager', 'white-bg'
-  - Premium styles (require token): 'satellite', 'satellite-streets', 'outdoors', 'streets', 'light', 'dark'
-  - Updated documentation with correct style options and Mapbox token usage
+### Features
 
-### Changed
-- **GUI favicon and title**:
-  - Replaced default Vite favicon with Niamoto branding
-  - Changed browser title from "Vite + React + TS" to "Niamoto"
-  - Added comprehensive favicon support (ico, svg, apple-touch-icon, webmanifest)
-- **Transform configuration structure** (BREAKING CHANGE):
-  - Replaced `source` + `additional_sources` with a unified `sources` list
-  - Each source now requires a unique `name` identifier
-  - Widgets reference sources by name via `params.source`
-  - Updated all configuration examples and documentation
-  - Example migration:
-    ```yaml
-    # Old structure
-    source:
-      data: occurrences
-      grouping: plot_ref
-    additional_sources:
-      plot_stats:
-        data: imports/plot_stats.csv
+- Introduce Tropicos enricher plugin for enhanced taxonomy data enrichment
+- Enhance ShapeImporter and StatsLoader for improved feature handling and ID generation
+- Introduce comprehensive GUI enhancements and CLI improvements
+- Update CLI help message and initialization options
+- Enhance interactive map functionality with Mapbox support
+- Implement hierarchical shape support and enhancements
+- Implement new Shape ID generation format in documentation and code
+- Enhance geospatial extraction and interactive map functionality
+- Enhance FieldAggregator to support JSON field access
+- Add project initialization and metadata enhancements
+- Integrate i18n support across components and add language switcher
+- Enhance shape import functionality and configuration management
+- Introduce faceted spinner and enhance circular progress component
+- Enhance import process with progress tracking and new UI components
+- Add table fields retrieval and enhance import field handling
+- Enhance PlotImporter and import functionality
+- Enhance ShapeProcessor to support group_id configuration
+- Update documentation and configuration for multiple data sources
+- Enhance import functionality with progress tracking and hierarchy configuration
+- Implement new import-v2 interface with enhanced functionality
+- Introduce taxonomy hierarchy configuration and streamline import process
+- Integrate httpx for enhanced API interactions and improve import functionality
+- Enhance import wizard and API integration for improved data handling
+- Add React-based GUI configuration interface for Niamoto
 
-    # New structure
-    sources:
-      - name: occurrences
-        data: occurrences
-        grouping: plot_ref
-      - name: plot_stats
-        data: imports/plot_stats.csv
-    ```
+### Bug Fixes
 
-### Fixed
-- Corrected webmanifest paths from `/assets/` to `/favicon/`
-- **Field aggregator plugin**: Fixed extraction of JSON fields (e.g., `extra_data.field_name`) when data is passed as DataFrame
-  - Plugin can now properly parse JSON columns and extract nested values
-  - Resolves issue where `extra_data` fields returned null values
-- **Geospatial extractor**: Added support for MultiPoint geometries
-  - Plugin now correctly handles MultiPoint geometries for hierarchical plot levels
-  - Returns proper GeoJSON with MultiPoint features instead of empty results
-- **Interactive map widget**: Enhanced to support MultiPoint geometries
-  - Widget now handles MultiPoint features by calculating centroids for display
-  - Fixed issue where hierarchical plot levels with MultiPoint geometries were not displayed on maps
-  - Automatically adapts when configuration expects polygons but data contains Point/MultiPoint geometries
+- Update API URL and enhance drag-and-drop functionality in import wizard
+- Prevent rendering of empty widgets in WidgetPlugin and RadialGaugeWidget
+- Improve zoom level calculation in InteractiveMapWidget
+- Update parent linking logic in TaxonomyImporter
+- Update drag-and-drop cursor styles and hierarchy level descriptions
+- Correct hierarchy level description in PlotHierarchyConfig component
+- Standardize field naming in advanced options for import functionality
+
+### Refactoring
+
+- Improve geospatial data handling in GeospatialExtractor
+- Unify source configuration structure across documentation and code
+- Remove taxon estimation logic from OccurrencesStep and SummaryStep
+- Streamline import wizard and remove deprecated components
 
 ## [v0.6.2] - 2025-07-15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,11 @@ If the answer is already discoverable from the code or config, prefer checking f
 
 Use repo-local skills only when they are available in the current environment and clearly help with the task.
 
+- `niamoto-release` — Full release pipeline: version bump, PyPI, GitHub Release, CI monitoring. Usage: `/release [patch|minor|major]`
+- `niamoto-plugin-generator` — Scaffold Transformer/Widget/Loader/Exporter with tests
+- `niamoto-test-data-generator` — Generate realistic ecological test datasets
+- `niamoto-config-validator` — Validate YAML configs, detect typos with suggestions
+
 ## Commands
 
 Typical validation workflow:
@@ -98,3 +103,5 @@ When tempted to hardcode, ask: "Would this work for a forest inventory in Madaga
 - GUI code-level docs:
   - `src/niamoto/gui/README.md`
   - `src/niamoto/gui/ui/README.md`
+- Release process: `.github/RELEASE.md`
+- Version files synced by bump2version: `pyproject.toml`, `src/niamoto/__version__.py`, `docs/conf.py`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`

--- a/docs/plans/2026-03-25-feat-niamoto-release-automation-skill-plan.md
+++ b/docs/plans/2026-03-25-feat-niamoto-release-automation-skill-plan.md
@@ -1,0 +1,619 @@
+---
+title: "feat: Niamoto Release Automation Skill"
+type: feat
+date: 2026-03-25
+---
+
+# Niamoto Release Automation Skill (`/release`)
+
+## Overview
+
+Skill Claude Code qui automatise l'intégralité du pipeline de release Niamoto : merge PR, bump de version, vérification des builds, publication PyPI, création de release GitHub, builds cross-platform (PyInstaller + Tauri), et rebuild de la documentation Sphinx/ReadTheDocs.
+
+Mode **semi-automatique** : le skill exécute toutes les vérifications, présente un résumé, puis demande une seule confirmation avant de tout publier.
+
+## Problem Statement
+
+Le processus de release actuel est fragmenté et manuel :
+- `bump2version` pour le versioning (4 fichiers synchronisés, mais pas `Cargo.toml`)
+- `scripts/build/publish.sh` pour PyPI (script bash interactif)
+- `scripts/build/build_gui.sh` pour le build React
+- GitHub Actions `build-binaries.yml` déclenché manuellement sur tag push (PyInstaller uniquement)
+- Pas de workflow CI pour les builds Tauri
+- Pas de workflow CI pour la publication PyPI
+- Pas de CHANGELOG.md
+- Pas de vérification pré-release intégrée
+- ReadTheDocs rebuild déclenché par webhook sur push (non vérifié)
+
+**Risques du processus actuel** : oubli d'un fichier de version, publication avec des tests cassés, versions désynchronisées entre Python et Tauri, pas de traçabilité des changements.
+
+## Proposed Solution
+
+Un skill Claude Code `/release` qui orchestre le pipeline complet en 3 phases :
+
+```
+Phase 1: PREFLIGHT (vérifications locales + CI)
+Phase 2: PREPARE (bump, changelog, commit, tag)
+Phase 3: PUBLISH (push, PyPI, release GitHub, CI builds, docs)
+```
+
+### Invocation
+
+```bash
+/release              # Auto-détection du type de bump
+/release patch        # Force patch
+/release minor        # Force minor
+/release major        # Force major
+/release --dry-run    # Simule sans rien publier
+```
+
+## Technical Approach
+
+### Architecture du Skill
+
+Le skill est un fichier SKILL.md installé dans les skills Claude Code du projet. Il orchestre des commandes bash existantes et des appels `gh` CLI.
+
+### Inventaire complet des fichiers de version
+
+| Fichier | Champ | Géré par bump2version | Statut |
+|---------|-------|----------------------|--------|
+| `pyproject.toml` | `version = "X.Y.Z"` | Oui | OK |
+| `src/niamoto/__version__.py` | `__version__ = "X.Y.Z"` | Oui | OK |
+| `docs/conf.py` | `release = "X.Y.Z"` | Oui | OK |
+| `src-tauri/tauri.conf.json` | `"version": "X.Y.Z"` | Oui | OK |
+| `src-tauri/Cargo.toml` | `version = "0.1.0"` | **Non** | **A ajouter** |
+| `.bumpversion.cfg` | `current_version = X.Y.Z` | Auto-géré | OK |
+
+### Phase 1 : PREFLIGHT
+
+Vérifications séquentielles avec arrêt au premier échec :
+
+```
+1.1  Working tree propre (git status)
+1.2  Branche = main (ou merge PR si sur feature branch)
+1.3  Main à jour avec origin/main (git fetch + compare)
+1.4  Pas de PR ouverte en attente de merge (optionnel: proposer de merger)
+1.5  Tests Python passent (uv run pytest)
+1.6  Linting passe (uvx ruff check src/)
+1.7  Build GUI React (cd src/niamoto/gui/ui && pnpm install && pnpm run build)
+1.8  Build Tauri local macOS (cd src-tauri && cargo build --release)
+1.9  Analyse des commits depuis le dernier tag pour suggestion de bump
+```
+
+**Gestion PR (étape 1.2-1.4)** :
+- Si sur une feature branch avec PR ouverte vers main :
+  - Vérifier que la CI passe sur la PR
+  - Proposer de merger la PR via `gh pr merge --squash`
+  - Checkout main + pull
+- Si sur main mais PR ouverte non mergée :
+  - Avertir l'utilisateur, continuer ou annuler
+
+**Analyse des commits (étape 1.9)** :
+```
+feat:            → minor
+fix:, perf:      → patch
+refactor:, docs: → patch
+BREAKING CHANGE  → major (dans footer ou feat!:)
+chore:, style:   → patch
+```
+Afficher la suggestion avec la liste des commits classés, demander confirmation.
+
+### Phase 2 : PREPARE
+
+Actions locales réversibles :
+
+```
+2.1  Créer/mettre à jour CHANGELOG.md (format Keep a Changelog)
+2.2  Bump version via bump2version (+ patch Cargo.toml si ajouté)
+2.3  Commit de release : "release: vX.Y.Z"
+2.4  Tag git : vX.Y.Z
+```
+
+**Format CHANGELOG.md** (Keep a Changelog) :
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [X.Y.Z] - 2026-03-25
+
+### Added
+- feat: description (from commit messages)
+
+### Fixed
+- fix: description
+
+### Changed
+- refactor: description
+
+## [0.9.0] - 2026-03-XX
+...
+```
+
+**Point de confirmation** : Après la phase 2, afficher un résumé complet :
+```
+=== Release Summary ===
+Version: 0.9.0 → 0.10.0 (minor)
+Commits: 12 (5 feat, 4 fix, 3 refactor)
+Files modified: 5 (pyproject.toml, __version__.py, docs/conf.py, tauri.conf.json, Cargo.toml)
+CHANGELOG: 12 entries added
+
+Preflight results:
+  Tests:     142 passed, 0 failed
+  Linting:   0 errors
+  GUI build: OK (dist/ 2.1 MB)
+  Tauri:     OK (macOS arm64)
+
+Ready to publish? [y/N]
+```
+
+### Phase 3 : PUBLISH
+
+Actions irréversibles (après confirmation unique) :
+
+```
+3.1  git push origin main --follow-tags
+3.2  Build wheel PyPI avec GUI inclus (scripts/build/publish.sh logic)
+3.3  Publish sur PyPI (uv publish)
+3.4  Créer GitHub Release via gh release create
+3.5  Monitorer CI: build-binaries.yml (déclenché par le tag)
+3.6  Monitorer CI: workflow Tauri (à créer)
+3.7  Vérifier rebuild ReadTheDocs
+```
+
+**Publication PyPI (étape 3.2-3.3)** :
+Le skill reproduit la logique de `scripts/build/publish.sh` :
+1. Activer l'inclusion GUI dans `pyproject.toml` (uncomment `force-include`)
+2. `uv build --wheel`
+3. Restaurer `pyproject.toml`
+4. `uv build --sdist`
+5. `uv publish` avec token ou OIDC
+
+**Monitoring CI (étapes 3.5-3.6)** :
+```bash
+# Attendre que le workflow démarre
+gh run list --workflow=build-binaries.yml --limit 1 --json status,conclusion
+
+# Suivre l'exécution
+gh run watch <run_id>
+```
+
+**ReadTheDocs (étape 3.7)** :
+ReadTheDocs est configuré avec un webhook GitHub. Le push du tag déclenche automatiquement un rebuild. Le skill vérifie le statut via :
+```bash
+# Vérification simple : le tag apparaît dans les versions RTD
+# Alternative : API RTD si un token est configuré
+curl -s "https://readthedocs.org/api/v3/projects/niamoto/versions/" \
+  -H "Authorization: Token $RTD_TOKEN" | jq '.results[0]'
+```
+
+### Workflows GitHub Actions à créer
+
+#### 1. Workflow PyPI Publish (`publish-pypi.yml`)
+
+```yaml
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write  # Pour OIDC Trusted Publishers
+
+jobs:
+  build-gui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+          cache-dependency-path: src/niamoto/gui/ui/pnpm-lock.yaml
+      - run: cd src/niamoto/gui/ui && pnpm install --frozen-lockfile && pnpm run build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: gui-dist
+          path: src/niamoto/gui/ui/dist/
+
+  publish:
+    needs: build-gui
+    runs-on: ubuntu-latest
+    environment: pypi  # Environnement GitHub pour OIDC
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - uses: actions/download-artifact@v8
+        with:
+          name: gui-dist
+          path: src/niamoto/gui/ui/dist/
+      - name: Enable GUI in wheel
+        run: |
+          sed -i 's/# "src\/niamoto\/gui\/ui\/dist"/"src\/niamoto\/gui\/ui\/dist"/' pyproject.toml
+      - name: Build
+        run: |
+          pip install uv
+          uv build --wheel
+          # Restore and build sdist without GUI
+          git checkout pyproject.toml
+          uv build --sdist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Avec Trusted Publishers, pas besoin de token
+```
+
+#### 2. Workflow Tauri Build (`build-tauri.yml`)
+
+```yaml
+name: Build Tauri Desktop
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  build-tauri:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            name: macOS-arm64
+            target: aarch64-apple-darwin
+          - os: ubuntu-22.04
+            name: Linux-x86_64
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            name: Windows-x86_64
+            target: x86_64-pc-windows-msvc
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system deps (Linux)
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev \
+            libappindicator3-dev librsvg2-dev patchelf \
+            gdal-bin libgdal-dev libproj-dev
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install Python package
+        run: |
+          pip install uv
+          uv venv
+          uv pip install -e .
+
+      - name: Build Python binary (PyInstaller)
+        run: |
+          uv pip install pyinstaller
+          uv run pyinstaller build_scripts/niamoto.spec --clean --noconfirm
+          # Copy binary to src-tauri/bin/
+          mkdir -p src-tauri/bin
+          cp dist/niamoto${{ matrix.os == 'windows-latest' && '.exe' || '' }} \
+             src-tauri/bin/niamoto-${{ matrix.target }}${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+          cache-dependency-path: src/niamoto/gui/ui/pnpm-lock.yaml
+
+      - name: Install frontend deps
+        run: cd src/niamoto/gui/ui && pnpm install --frozen-lockfile
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Tauri
+        uses: tauri-apps/tauri-action@v0
+        with:
+          projectPath: src-tauri
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: tauri-${{ matrix.name }}
+          path: src-tauri/target/release/bundle/**/*
+```
+
+#### 3. Workflow Docs Check (`docs-check.yml`) — optionnel
+
+```yaml
+name: Docs Build Check
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - run: |
+          pip install -e ".[dev]"
+          cd docs && make html
+```
+
+### Pré-requis : Corrections à apporter avant le skill
+
+#### 1. Ajouter `Cargo.toml` au bump2version
+
+```ini
+# .bumpversion.cfg — ajouter :
+[bumpversion:file:src-tauri/Cargo.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+```
+
+**Attention** : Le `Cargo.toml` a actuellement `version = "0.1.0"` alors que le reste est à `0.9.0`. Il faut d'abord aligner manuellement, puis ajouter au bump2version.
+
+#### 2. Créer le CHANGELOG.md initial
+
+Générer un CHANGELOG rétroactif à partir des tags existants (v0.7.1 → v0.9.0) ou démarrer avec la prochaine release.
+
+#### 3. Configurer PyPI Trusted Publishers (recommandé)
+
+Sur pypi.org → Manage project → Publishing :
+- Publisher: GitHub Actions
+- Owner: `niamoto`
+- Repository: `niamoto`
+- Workflow: `publish-pypi.yml`
+- Environment: `pypi`
+
+#### 4. Configurer les GitHub Environments
+
+Créer l'environnement `pypi` dans Settings → Environments avec protection rules (required reviewers optionnel).
+
+## Alternative Approaches Considered
+
+### python-semantic-release (rejeté)
+
+Outil tout-en-un qui analyse les commits et publie automatiquement. Rejeté car :
+- Trop opinionated, difficile à personnaliser pour le cas multi-artifact (Python + Tauri)
+- Ne gère pas le build GUI ni le Tauri
+- Le skill Claude Code offre plus de flexibilité et de visibilité
+
+### GitHub Actions only (rejeté)
+
+Tout automatiser via GitHub Actions sans skill Claude Code. Rejeté car :
+- Perd l'aspect interactif et la confirmation utilisateur
+- Plus difficile à débugger quand quelque chose échoue
+- Le skill permet des vérifications locales avant de pousser
+
+### Makefile / Just (complémentaire)
+
+Un `Justfile` pourrait encapsuler les commandes de build. Le skill Claude Code appellerait ces commandes. Option à considérer pour la phase d'implémentation.
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] `/release` analyse les commits et suggère le type de bump (patch/minor/major)
+- [ ] L'utilisateur peut override le type de bump suggéré
+- [ ] `/release --dry-run` simule sans rien modifier
+- [ ] Le skill vérifie que le working tree est propre
+- [ ] Le skill vérifie que la branche est main (ou propose de merger la PR)
+- [ ] Les tests Python passent avant toute publication
+- [ ] Le linting ruff passe avant toute publication
+- [ ] Le GUI React build réussit avant toute publication
+- [ ] Le build Tauri local (macOS) réussit avant toute publication
+- [ ] La version est bumpée dans **tous** les fichiers (y compris Cargo.toml)
+- [ ] Un CHANGELOG.md est généré/mis à jour au format Keep a Changelog
+- [ ] Un commit de release est créé : `release: vX.Y.Z`
+- [ ] Un tag git `vX.Y.Z` est créé
+- [ ] Le package est publié sur PyPI (wheel avec GUI + sdist sans GUI)
+- [ ] Une GitHub Release est créée avec les release notes
+- [ ] Les workflows CI cross-platform (PyInstaller) sont déclenchés et monitorés
+- [ ] Les workflows CI Tauri sont déclenchés et monitorés (à créer)
+- [ ] Le rebuild ReadTheDocs est vérifié
+- [ ] Un résumé final avec tous les liens (PyPI, GitHub Release, RTD) est affiché
+
+### Non-Functional Requirements
+
+- [ ] Le skill gère les erreurs gracieusement avec messages clairs
+- [ ] Chaque étape irréversible est précédée d'une confirmation
+- [ ] Le skill peut reprendre après un échec partiel (idempotence)
+- [ ] Temps total < 10 min pour la phase PREFLIGHT locale
+- [ ] Le skill ne stocke jamais de tokens/secrets en clair
+
+### Quality Gates
+
+- [ ] Le skill est testé sur un dry-run complet
+- [ ] La documentation du skill est complète (README dans le fichier SKILL.md)
+- [ ] Les workflows GitHub Actions sont testés via `workflow_dispatch`
+
+## Implementation Phases
+
+### Phase 1 : Fondations (pré-requis)
+
+**Objectif** : Aligner l'infrastructure existante
+
+- [x] Aligner `Cargo.toml` version sur `0.9.0`
+- [x] Ajouter `Cargo.toml` à `.bumpversion.cfg`
+- [x] Créer `CHANGELOG.md` initial (depuis v0.7.0, via generate_changelog.py)
+- [x] Créer le workflow `publish-pypi.yml`
+- [x] Créer le workflow `build-tauri.yml` (workflow_dispatch uniquement)
+- [ ] Configurer PyPI Trusted Publishers ou documenter la config token
+- [ ] Tester les workflows via `workflow_dispatch`
+
+**Livrable** : Infrastructure de release fonctionnelle via GitHub Actions
+
+### Phase 2 : Le Skill Claude Code
+
+**Objectif** : Créer le skill `/release`
+
+- [x] Écrire le SKILL.md avec les 3 phases (PREFLIGHT, PREPARE, PUBLISH)
+- [x] Implémenter l'analyse des conventional commits
+- [x] Implémenter le dry-run mode
+- [x] Implémenter la gestion de PR (merge avant release)
+- [x] Implémenter le monitoring CI via `gh run watch`
+- [x] Ajouter le skill aux skills du projet (CLAUDE.md)
+
+**Livrable** : Skill `/release` fonctionnel
+
+### Phase 3 : Polish
+
+**Objectif** : Robustesse et ergonomie
+
+- [ ] Gestion des cas d'erreur (CI fail, PyPI timeout, etc.)
+- [ ] Reprise après échec partiel
+- [ ] Ajout d'un mode `--only-check` (preflight uniquement)
+- [ ] Notifications de succès/échec (optionnel)
+- [ ] Documentation utilisateur complète
+
+**Livrable** : Skill production-ready
+
+## Dependencies & Prerequisites
+
+| Dépendance | Statut | Action |
+|-----------|--------|--------|
+| `bump2version` | Installé (dev dep) | OK |
+| `gh` CLI | Installé localement | Vérifier auth (`gh auth status`) |
+| `uv` | Installé | OK |
+| `pnpm` | Installé | OK |
+| `cargo` / Rust toolchain | Installé localement | Vérifier (`rustup show`) |
+| PyPI account + token | Existant (scripts/.env) | Migrer vers Trusted Publishers |
+| GitHub Actions secrets | `CODECOV_TOKEN` existe | Ajouter `PYPI_TOKEN` si pas OIDC |
+| ReadTheDocs webhook | Configuré | Vérifier qu'il se trigger sur tags |
+
+## Risk Analysis & Mitigation
+
+| Risque | Probabilité | Impact | Mitigation |
+|--------|------------|--------|------------|
+| PyPI publish échoue | Moyenne | Haute | Dry-run d'abord, fallback sur token manuel |
+| Tauri CI build échoue (deps système) | Haute | Moyenne | Tester workflow_dispatch avant la première release |
+| Version mismatch résiduel | Faible | Haute | Vérification post-bump de tous les fichiers |
+| ReadTheDocs ne rebuild pas sur tag | Faible | Faible | Fallback : trigger manuel via API RTD |
+| PR merge conflict | Moyenne | Moyenne | Le skill détecte et demande résolution manuelle |
+| Tag déjà existant | Faible | Haute | Vérification `git tag -l vX.Y.Z` avant de tagger |
+| Partial publish (tag pushé mais PyPI échoue) | Faible | Haute | Ordre : PyPI d'abord, puis tag push (ou atomic) |
+
+**Point critique** : L'ordre des opérations dans la Phase 3 est important. Si on push le tag d'abord et que PyPI échoue, on a une release GitHub sans package PyPI. **Solution** : publier sur PyPI avant de push le tag, ou utiliser un workflow CI déclenché par `release: published`.
+
+### Ordre des opérations recommandé (Phase PUBLISH)
+
+```
+3.1  Build wheel + sdist localement (vérifier que ça build)
+3.2  Push commits + tag vers GitHub
+3.3  → CI: tests.yml se déclenche (push sur main)
+3.4  → CI: build-binaries.yml se déclenche (tag v*)
+3.5  → CI: build-tauri.yml se déclenche (tag v*)
+3.6  Créer GitHub Release (draft)
+3.7  → CI: publish-pypi.yml se déclenche (release published)
+3.8  OU: publish PyPI localement via uv publish
+3.9  → ReadTheDocs rebuild (webhook sur tag push)
+3.10 Monitorer tous les workflows
+3.11 Afficher résumé final avec liens
+```
+
+**Option A** (recommandée) : PyPI via GitHub Actions (Trusted Publishers, OIDC)
+- Plus sécurisé (pas de token à gérer)
+- Reproductible
+- Déclenché par `release: published`
+
+**Option B** : PyPI local via `uv publish`
+- Plus rapide pour debug
+- Nécessite un token PyPI local
+- Garde la logique de `scripts/build/publish.sh`
+
+## Documentation Plan
+
+| Document | Action |
+|---------|--------|
+| `SKILL.md` (le skill lui-même) | Créer |
+| `CLAUDE.md` | Ajouter le skill à la liste des skills |
+| `docs/development-commands.md` | Ajouter section Release |
+| `scripts/build/publish.sh` | Garder comme fallback, documenter relation avec le skill |
+| `.github/workflows/publish-pypi.yml` | Créer + documenter |
+| `.github/workflows/build-tauri.yml` | Créer + documenter |
+
+## References & Research
+
+### Internal References
+
+- Version management: `.bumpversion.cfg`
+- Current publish script: `scripts/build/publish.sh`
+- GUI build: `scripts/build/build_gui.sh`
+- CI tests: `.github/workflows/tests.yml`
+- CI binaries: `.github/workflows/build-binaries.yml`
+- Tauri config: `src-tauri/tauri.conf.json`
+- Sphinx docs: `docs/conf.py` + `.readthedocs.yaml`
+- Python version: `src/niamoto/__version__.py`
+
+### External References
+
+- [PyPI Trusted Publishers](https://docs.pypi.org/trusted-publishers/)
+- [gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)
+- [Tauri GitHub Action](https://github.com/tauri-apps/tauri-action)
+- [Keep a Changelog](https://keepachangelog.com/)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [bump2version](https://github.com/c4urself/bump2version)
+
+### Related Work
+
+- Existing tags: v0.7.1 through v0.9.0
+- Latest release: v0.8.1 (2026-03-15)
+- Existing skill: `changelog` (slash command pour CHANGELOG)
+
+## Diagramme de flux
+
+```mermaid
+flowchart TD
+    A["/release [type]"] --> B{Working tree propre?}
+    B -->|Non| B1[Erreur: commit ou stash d'abord]
+    B -->|Oui| C{Sur main?}
+    C -->|Non| D{PR ouverte?}
+    D -->|Oui| E[Proposer merge PR]
+    E --> F[Checkout main + pull]
+    D -->|Non| D1[Erreur: créer une PR d'abord]
+    C -->|Oui| G[Fetch origin/main]
+    F --> G
+    G --> H{Main à jour?}
+    H -->|Non| H1[git pull --rebase]
+    H -->|Oui| I[Run tests + lint]
+    H1 --> I
+    I -->|Fail| I1[Erreur: fixer les tests]
+    I -->|Pass| J[Build GUI React]
+    J -->|Fail| J1[Erreur: fixer le build GUI]
+    J -->|Pass| K[Build Tauri local macOS]
+    K -->|Fail| K1[Warning: Tauri build failed]
+    K -->|Pass| L[Analyser commits → suggestion bump]
+    K1 --> L
+    L --> M[Confirmation utilisateur]
+    M -->|Annuler| M1[Abort]
+    M -->|Confirmer| N[Bump version + CHANGELOG + commit + tag]
+    N --> O[Push origin main --follow-tags]
+    O --> P[Créer GitHub Release]
+    P --> Q[Publish PyPI ou CI workflow]
+    Q --> R[Monitorer CI builds]
+    R --> S[Vérifier ReadTheDocs]
+    S --> T[Résumé final avec liens]
+
+    style B1 fill:#f66
+    style D1 fill:#f66
+    style I1 fill:#f66
+    style J1 fill:#f66
+    style K1 fill:#ff9
+    style M1 fill:#f66
+    style T fill:#6f6
+```

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "app"
-version = "0.1.0"
-description = "A Tauri App"
-authors = ["you"]
+version = "0.9.0"
+description = "Niamoto Desktop - Ecological data platform"
+authors = ["Julien Barbe"]
 license = ""
 repository = ""
 edition = "2021"


### PR DESCRIPTION
## Summary
- Align `Cargo.toml` version (0.1.0 -> 0.9.0) and add to bumpversion sync (5 files now)
- Create `publish-pypi.yml` workflow with OIDC Trusted Publishers (no token needed)
- Create `build-tauri.yml` workflow (manual trigger only, cross-platform)
- Regenerate `CHANGELOG.md` from v0.2.0 with `[Unreleased]` section
- Document release skill and version files in `CLAUDE.md`
- PyPI Trusted Publisher configured (niamoto/niamoto, publish-pypi.yml, env pypi)
- GitHub environment `pypi` created

## Context
Infrastructure for the `/release` skill (SKILL.md in agent-skills repo, symlinked).

## Test plan
- [ ] Verify `publish-pypi.yml` via workflow_dispatch after merge
- [ ] Verify `build-tauri.yml` via workflow_dispatch
- [ ] Run `/release --dry-run` to validate the skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added GitHub Actions workflows for building desktop applications on macOS, Ubuntu, and Windows platforms
  * Added GitHub Actions workflow for automated PyPI publishing
  * Bumped version to v0.9.0 with comprehensive release notes and changelog updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->