### PR TITLE
feat: extend pre-import impact checks

### DIFF
--- a/docs/brainstorms/2026-03-30-data-compatibility-check-brainstorm.md
+++ b/docs/brainstorms/2026-03-30-data-compatibility-check-brainstorm.md
@@ -1,0 +1,274 @@
+---
+title: Pre-Import Impact Check
+topic: Config-first impact analysis on source data re-upload
+date: 2026-03-30
+status: approved
+---
+
+# Pre-Import Impact Check
+
+## What We're Building
+
+A **pre-import impact check** that analyzes new source files against the existing pipeline configuration when a user re-uploads data. Not a simple schema diff — the check tells the user the **business impact** of their data changes on the import/transform pipeline.
+
+**Framing:** The configuration (import.yml + transform.yml relation keys) is the **source of truth**. The EntityRegistry provides context (what changed since last import), not ground truth. The UX shows pipeline impact, not just technical differences.
+
+### User Story
+
+A field botanist has already set up their Niamoto instance — data imported, groups configured, pages generated and published. Months later, they come back with updated data (new occurrences, new plots, expanded geography). They go to the Sources page, upload their new files via the ImportWizard, and **before the import runs**, they see a clear report: what's compatible, what's missing, what's new.
+
+### Phasing
+
+**V1 (this plan):** CSV only, coarse type inference, compare against import.yml + relation keys in transform.yml, rendered in ImportWizard.
+
+**V2 (future):** GPKG support (native schema metadata), plugin-aware transform.yml reference collection (scan `params` recursively per plugin type).
+
+### Scope (V1)
+
+- **UI**: Compatibility panel in ImportWizard, between upload step and import step
+- **CLI**: Subcommand `niamoto import check`
+- **Backend**: Shared service in `src/niamoto/core/services/`
+- **Non-blocking**: Warnings only, user decides whether to proceed
+- **CSV only**: GPKG and other formats deferred to V2
+
+## Why This Approach
+
+### Chosen: Lightweight header + sample comparison (Approach A)
+
+Read CSV headers and a small sample (~100 rows) to infer column names and coarse types. Compare against the current EntityRegistry metadata and column references in import.yml + transform.yml relation keys.
+
+**Why not DuckDB DESCRIBE (Approach B)?** Accurate types are nice but overkill — the user mainly cares about missing columns and obvious type shifts (numeric → text). A Python-only approach is simpler, faster, doesn't need a DB connection, and is easier to test.
+
+**Why not full profiling (Approach C)?** Way too complex for the stated need. The user wants a quick sanity check, not a data quality audit.
+
+**Why CSV-only for V1?** The AutoConfigService currently only processes CSV. The types stored in the engine are coarse. Starting with CSV covers the most common use case and lets us validate the UX before adding format-specific complexity.
+
+## Key Decisions
+
+1. **Trigger**: Automatic on file re-upload in ImportWizard — no extra clicks needed
+2. **Scope V1**: CSV only, coarse types, import.yml + relation keys
+3. **Behavior**: Non-blocking warning with clear actionable info
+4. **CLI**: Subcommand `niamoto import check` (under the import group)
+5. **UI**: Panel in ImportWizard, after upload step, before import step
+6. **Architecture**: Core service shared between CLI and API
+7. **API**: `POST /api/imports/impact-check` (single endpoint: resolve + check)
+8. **DERIVED entities**: Excluded from check with message pointing to source dataset
+9. **File-to-entity mapping**: Resolver matches uploaded filename against import.yml `connector.path` (exact match, first wins)
+10. **First import (no config)**: Skip check silently — nothing to compare against
+11. **CLI exit code**: Non-zero (1) when issues found — useful for CI/CD
+12. **transform.yml**: V1 checks only relation keys (`key`, `ref_key`, `ref_field`). V2 adds plugin-aware `params` scanning
+
+## Design
+
+### Service Layer
+
+New `CompatibilityService` in `src/niamoto/core/services/compatibility.py`:
+
+```python
+@dataclass
+class ColumnMatch:
+    name: str
+    old_type: str
+    new_type: str
+
+class ImpactLevel(str, Enum):
+    BLOCKS_IMPORT = "blocks_import"         # missing column in import.yml schema/links
+    BREAKS_TRANSFORM = "breaks_transform"   # missing column in transform.yml relation keys
+    WARNING = "warning"                     # type change, may cause downstream issues
+    OPPORTUNITY = "opportunity"             # new column, not yet in config
+
+@dataclass
+class ImpactItem:
+    column: str
+    level: ImpactLevel
+    detail: str           # human-readable explanation
+    referenced_in: list[str]
+    # e.g. ["import.yml > occurrences > links > field",
+    #        "transform.yml > group forest > relation > key"]
+    old_type: str | None = None  # for type changes
+    new_type: str | None = None
+
+@dataclass
+class ImpactReport:
+    entity_name: str
+    file_path: str
+    matched_columns: list[ColumnMatch]  # columns present in both, no issue
+    impacts: list[ImpactItem]           # all issues and opportunities, sorted by severity
+    error: str | None = None            # read error (corrupt file, bad encoding, etc.)
+    skipped_reason: str | None = None   # why check was skipped (DERIVED, no config, etc.)
+
+    @property
+    def has_blockers(self) -> bool:
+        return any(i.level == ImpactLevel.BLOCKS_IMPORT for i in self.impacts)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(i.level in (ImpactLevel.BREAKS_TRANSFORM, ImpactLevel.WARNING)
+                   for i in self.impacts)
+
+    @property
+    def has_opportunities(self) -> bool:
+        return any(i.level == ImpactLevel.OPPORTUNITY for i in self.impacts)
+```
+
+The service (V1):
+1. **Read new file schema**: Reads CSV using the same logic as `GenericImporter._import_csv()` in `engine.py` but with `LIMIT` — reuses DuckDB's `read_csv_auto()` or the engine's separator/encoding detection to avoid check/import divergence. Extracts column names and the coarse types the engine actually persists (aligned with `FieldType` enum).
+   - Unreadable/corrupt files: return report with `error` field set
+2. **Build config reference map (source of truth)**: Parses import.yml → entity schema fields, links, hierarchy columns, extraction columns. Parses transform.yml → relation keys only (`key`, `ref_key`, `ref_field`, `fields` mapping). Builds `{column_name: [(reference_path, impact_level)]}`.
+3. **Enrich with registry context**: Loads EntityRegistry metadata `config["schema"]["fields"]` to compare current vs new types and detect what changed since last import.
+4. **Produce impact report**: For each referenced column, classify the impact:
+   - Missing column in import.yml schema/links → `BLOCKS_IMPORT`
+   - Missing column in transform.yml relation keys → `BREAKS_TRANSFORM`
+   - Type change on referenced column → `WARNING`
+   - New column not in config → `OPPORTUNITY`
+
+**Connector-specific behavior:**
+- **FILE / DUCKDB_CSV**: Normal check against CSV source file
+- **VECTOR**: Skipped in V1, supported in V2 (GPKG native schema)
+- **DERIVED**: Skip with `skipped_reason = "Derived from {source} — check {source} instead"`
+- **FILE_MULTI_FEATURE**: Skipped in V1, supported in V2
+- **API / PLUGIN**: Skip with `skipped_reason = "External connector — cannot check locally"`
+
+### Entity Resolver
+
+New `EntityResolver` (part of CompatibilityService or standalone utility):
+
+```python
+def resolve_entity(filename: str, import_config: dict) -> str | None:
+    """Match an uploaded filename to an entity via import.yml connector.path.
+
+    Returns:
+      - entity_name (str) if exact basename match found (first wins)
+      - None if no match found
+    """
+```
+
+Matching strategy — conservative, exact-match only:
+1. Compare `filename` against each entity's `connector.path` basename (e.g. `imports/occurrences.csv` → `occurrences.csv`)
+2. If exact basename match → return entity name
+3. If no exact match → return None, no check triggered (normal auto-configure flow)
+
+No fuzzy/stem matching in V1. False positives from loose matching would be worse than no check at all. If the user renames their file, the resolver simply doesn't match and the normal auto-configure flow handles it.
+
+### Config Reference Collection (V1)
+
+V1 focuses on import.yml and relation keys in transform.yml:
+
+| Config file | Path | What it references |
+|---|---|---|
+| import.yml | `entities.datasets.{name}.schema.fields` | Declared columns |
+| import.yml | `entities.datasets.{name}.schema.id_field` | Primary key column |
+| import.yml | `entities.datasets.{name}.links[].field` | Link source column |
+| import.yml | `entities.datasets.{name}.links[].target_field` | Link target column |
+| import.yml | `entities.references.{name}.hierarchy.levels[].column` | Hierarchy column |
+| import.yml | `entities.references.{name}.connector.extraction.id_column` | Extraction ID column |
+| import.yml | `entities.references.{name}.connector.extraction.name_column` | Extraction name column |
+| import.yml | `entities.references.{name}.connector.extraction.levels[].column` | Extraction level columns |
+| import.yml | `entities.references.{name}.connector.extraction.additional_columns` | Extra extraction columns |
+| transform.yml | `sources[].relation.key` | Join key in source |
+| transform.yml | `sources[].relation.ref_key` / `ref_field` | Join key in reference |
+| transform.yml | `sources[].relation.fields` | Field mapping values (e.g. `parent: parent_id` → checks `parent_id`) |
+
+**V2 addition:** Plugin-aware scanning of `widgets_data.{w}.params` — requires knowing which param keys are column references per plugin type (`field`, `fields[].field`, `columns`, `referential_data`, etc.). This needs a plugin metadata registry or convention.
+
+**Note:** export.yml is out of scope — it references widget outputs, not source columns.
+
+### API Endpoint
+
+Single endpoint — resolves entity internally then runs check. Simpler frontend orchestration:
+
+```
+POST /api/imports/impact-check
+Body: { "file_path": "imports/occurrences.csv" }
+Response: { entity_name: str|null, matched_columns: [...], impacts: [...], ... }
+```
+
+If `entity_name` is null, no match was found and the frontend skips the panel. Added to existing router `src/niamoto/gui/api/routers/imports.py`.
+
+### CLI Command
+
+```bash
+niamoto import check                    # check all entities
+niamoto import check --entity taxons    # check one entity
+```
+
+Subcommand of the `import` group in `src/niamoto/cli/commands/imports.py`. Iterates over import.yml entities, checks each source file, outputs a color-coded terminal report (green/orange/red). Exit code 0 = all compatible, exit code 1 = issues found.
+
+### Frontend Component
+
+`CompatibilityPanel` in `src/niamoto/gui/ui/src/features/import/components/`:
+
+- Lives in the **ImportWizard** flow, as a step between upload and import execution
+- After file upload completes, if an existing entity is detected (via EntityResolver):
+  - Call `POST /api/imports/compatibility`
+  - Show the CompatibilityPanel with results
+- Impact-oriented categories (not just schema diff):
+  - Red: **Blocks import** — missing columns referenced in import.yml (schema, links)
+  - Orange: **Breaks transform** — missing columns referenced in transform.yml relations
+  - Yellow: **Warning** — type changes on referenced columns
+  - Blue: **Opportunity** — new columns not yet in config
+  - Green: matched columns (count only, collapsed by default)
+- Two actions: **"Continue anyway"** (proceeds to import step) / **"Fix data"** (goes back to upload step)
+
+### Integration Points
+
+**Entity resolution — integrated in single endpoint:**
+The EntityResolver lives in the backend as part of `CompatibilityService`. The single `POST /api/imports/impact-check` endpoint resolves the entity internally from the `file_path` basename, then runs the check. No separate resolve call needed.
+
+After `POST /api/smart/upload-files` returns successfully, the frontend calls `/impact-check` for each uploaded file. If `entity_name` is null in the response, no match was found and the file proceeds to normal auto-configure flow.
+
+**First import detection:**
+If the EntityRegistry is empty or import.yml doesn't exist, skip the check entirely — there's nothing to compare against. No panel is shown.
+
+**Import flow**: The check is informational only — it does NOT gate the import. The user can always proceed.
+
+## Edge Cases Addressed
+
+| Case | Behavior |
+|---|---|
+| DERIVED entity (no source file) | Skip with message: "Derived from {source} — check {source}" |
+| FILE_MULTI_FEATURE (multiple files) | Skipped in V1, supported in V2 |
+| API / PLUGIN connector | Skip with message: "External connector — cannot check locally" |
+| VECTOR / GPKG | Skipped in V1, supported in V2 (native schema) |
+| First import (no config) | Skip silently — no panel shown |
+| File doesn't match any entity | No check triggered, normal auto-configure flow |
+| File matches multiple entities | V1: return None + log warning (avoid false positive). V2: disambiguation dropdown |
+| Empty file (0 rows, header only) | Columns match, types shown as "unknown" |
+| Corrupt/unreadable file | Report with `error` field, panel shows error message |
+| Renamed file | Falls through to auto-configure (exact match only, no fuzzy) |
+
+## V2 Roadmap
+
+Three independent workstreams, ordered by priority:
+
+### Critical guardrails
+
+- Keep V2 logic in the **pre-import impact check service**, not in the normal
+  import runtime. Extending the compatibility layer is acceptable; pushing V2
+  behavior into the import engine would increase fragility.
+- Do **not** deliver V2 as one large milestone. Ship `V2a`, `V2b`, and `V2c`
+  independently to contain complexity and keep regressions attributable.
+- Avoid heuristic "magic" for plugin params. If a param is treated as a source
+  column reference, that contract must be explicit in plugin metadata or a
+  dedicated hook.
+- Prefer additive extension points over more branching in one service:
+  composable reference providers, schema readers, and a small resolver/reader
+  registry.
+
+- **V2a — Plugin-aware param scanning** (highest priority): Explicit contract via
+  plugin `config_model` Pydantic fields or `collect_column_refs()` hook. No heuristic
+  name scanning. Refactor collectors into composable providers. This is the
+  highest complexity / fragility risk in V2 because it increases coupling with
+  the plugin ecosystem. Keep it read-only and preflight-only: no plugin
+  execution to determine references.
+- **V2b — GPKG reader**: Native schema from SQLite metadata. Then FILE_MULTI_FEATURE
+  with sub-report aggregation. Reader selection by connector type. Moderate risk
+  if isolated behind reader interfaces; high risk if implemented as special
+  cases spread through the core service.
+- **V2c — Disambiguation UI**: Dropdown when multiple entities share same filename.
+  No fuzzy/stem matching (too risky). Low technical risk if kept conservative.
+- **V3+ — Downstream widget severity**: Requires solid reference coverage first.
+
+## Open Questions
+
+None — all critical gaps resolved during spec review and user feedback.

--- a/docs/plans/2026-03-30-feat-pre-import-impact-check-auxiliary-sources-plan.md
+++ b/docs/plans/2026-03-30-feat-pre-import-impact-check-auxiliary-sources-plan.md
@@ -1,0 +1,376 @@
+---
+title: "feat: Pre-Import Impact Check V1.1 for Auxiliary Transform Sources"
+type: feat
+date: 2026-03-30
+brainstorm: docs/brainstorms/2026-03-30-data-compatibility-check-brainstorm.md
+related:
+  - docs/plans/2026-03-30-feat-pre-import-impact-check-plan.md
+---
+
+# feat: Pre-Import Impact Check V1.1 for Auxiliary Transform Sources
+
+## Overview
+
+Follow-up to V1 of the pre-import impact check.
+
+V1 works well for imported entities backed by `EntityRegistry` metadata (`occurrences`,
+`plots`, etc.), but it is not a good fit for raw auxiliary CSV sources used only
+during transform execution (`raw_plot_stats.csv`, `raw_shape_stats.csv`, similar
+class-object/statistics inputs).
+
+This plan introduces a small V1.1 extension that keeps the existing V1 behavior
+for imported entities while adding a separate, quieter, transform-oriented model
+for auxiliary sources.
+
+## Problem Statement
+
+Auxiliary transform sources are currently treated too much like imported entities,
+even though they are not imported into the database as first-class entities.
+
+That creates three problems:
+
+1. **No stable baseline**
+   - Imported entities can compare against `EntityRegistry`.
+   - Auxiliary transform sources usually cannot.
+   - Result: re-uploading the exact same file can produce a long list of `"new column"`
+     opportunities because the old schema is effectively unknown.
+
+2. **Wrong severity model**
+   - For `occurrences.csv`, a missing required column can block import.
+   - For `raw_plot_stats.csv`, the real consequence is different: the transform
+     pipeline breaks, but import itself is not the issue.
+
+3. **Reference coverage gap**
+   - V1 relation-key coverage is not enough for these files.
+   - Their columns are commonly consumed through transformer params such as:
+     - `direct_attribute.params.field`
+     - `field_aggregator.params.fields[*].field`
+   - Join-related config such as `match_field` is also important for these sources.
+
+## Goals
+
+- Preserve V1 behavior for imported entities.
+- Introduce an explicit `transform_source` target kind for raw auxiliary sources.
+- Add a dedicated persisted schema baseline for transform sources.
+- Cover the minimum high-value transform references for these sources.
+- Reduce noisy `"opportunity"` findings when no baseline exists yet.
+- Keep all logic in the compatibility/preflight layer, not in normal import runtime.
+
+## Non-Goals
+
+- Full plugin-aware scanning across all transformers and widgets.
+- GPKG support.
+- `FILE_MULTI_FEATURE` support.
+- Fuzzy filename matching.
+- Downstream widget severity analysis.
+- Refactoring `GenericImporter` or changing import execution semantics.
+
+## Proposed Solution
+
+Split the compatibility domain into two kinds of checked targets:
+
+1. **`import_entity`**
+   - Current V1 behavior.
+   - Baseline comes from `EntityRegistry`.
+   - Uses `BLOCKS_IMPORT`, `BREAKS_TRANSFORM`, `WARNING`, `OPPORTUNITY`.
+
+2. **`transform_source`**
+   - New V1.1 behavior for auxiliary CSV sources referenced by transforms.
+   - Baseline comes from a new persisted source-schema registry, not `EntityRegistry`.
+   - Main severities are `BREAKS_TRANSFORM` and `WARNING`.
+   - `"opportunity"` findings are suppressed or downgraded unless a baseline exists.
+
+## Scope Rules
+
+### What counts as a `transform_source`
+
+A file should be treated as `transform_source` when it is configured as a raw
+transform input rather than an imported entity. Initial scope:
+
+- `import.yml > auxiliary_sources[*]`
+- `transform.yml > sources[*].data` when `data` is a file path and the source is
+  not also a normal imported entity
+
+### Baseline behavior
+
+- `import_entity` baseline: `EntityRegistry`
+- `transform_source` baseline: new `TransformSourceRegistry`
+- If a `transform_source` has **no baseline yet**:
+  - run a required-columns check only
+  - suppress `"new column"` opportunities
+  - show a quiet informational UX state
+
+## Target Architecture
+
+```text
+CompatibilityService
+├── TargetResolver
+│   ├── import_entity (existing)
+│   └── transform_source (new)
+├── BaselineLoader
+│   ├── EntityRegistryBaselineLoader
+│   └── TransformSourceBaselineLoader
+├── RefsProviders
+│   ├── ImportRefsProvider
+│   ├── TransformRelationRefsProvider
+│   └── TransformPluginRefsProviderV1_1
+└── ImpactAnalyzer
+```
+
+## Key Design Decisions
+
+### 1. Separate baseline store for transform sources
+
+Do **not** force raw auxiliary sources into `EntityRegistry`.
+
+Introduce a dedicated persisted store, for example:
+
+- new module: `src/niamoto/core/imports/source_registry.py`
+- new table: `niamoto_metadata_transform_sources`
+
+Suggested stored fields:
+
+- `source_name`
+- `path`
+- `group_by`
+- `source_kind` (`transform_source`)
+- `schema_json`
+- `updated_at`
+
+Key choice should be stable enough to survive re-uploads:
+
+- primary lookup key: `source_name`
+- secondary validation data: `path`, `group_by`
+
+### 2. Minimal plugin-aware coverage in V1.1
+
+Do **not** jump directly to full V2 plugin-aware scanning.
+
+Only support the most important plugins for auxiliary sources:
+
+- `direct_attribute`
+- `field_aggregator`
+
+And add one missing relation field:
+
+- `relation.match_field`
+
+That gives immediate value for `raw_plot_stats.csv` / `raw_shape_stats.csv`
+without requiring changes across the full plugin ecosystem.
+
+### 3. Different finding policy for transform sources
+
+For `transform_source`, prioritize transform breakage detection over schema
+inventory reporting.
+
+Default behavior:
+
+- missing referenced column -> `BREAKS_TRANSFORM`
+- changed type on referenced column -> `WARNING`
+- extra column with baseline -> optional `OPPORTUNITY`
+- extra column without baseline -> no finding
+
+## Files to Create / Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/niamoto/core/services/compatibility.py` | Modify | Add target-kind split, baseline strategy, `match_field`, auxiliary-source rules |
+| `src/niamoto/core/imports/source_registry.py` | Create | Persist schema baselines for transform-only sources |
+| `src/niamoto/core/services/transformer.py` | Modify | Persist/update transform-source baseline after successful transform run |
+| `src/niamoto/gui/api/routers/imports.py` | Modify | Expose target kind / quieter transform-source semantics if needed |
+| `src/niamoto/gui/ui/src/features/import/components/CompatibilityPanel.tsx` | Modify | Render informational state for transform-source first baseline |
+| `tests/core/services/test_compatibility.py` | Modify | Add transform-source baseline and no-noise regression coverage |
+| `tests/core/imports/test_source_registry.py` | Create | Unit tests for persisted transform-source baselines |
+| `tests/gui/api/routers/test_imports.py` | Modify | API regression coverage for transform-source reports |
+
+## Implementation Phases
+
+### Phase 1: Introduce target kind split
+
+Extend the resolver/service flow so a matched file returns a structured target,
+not just an entity name.
+
+Suggested shape:
+
+```python
+@dataclass
+class ResolvedTarget:
+    kind: Literal["import_entity", "transform_source"]
+    name: str
+    file_path: str
+    group_by: Optional[str] = None
+```
+
+Rules:
+
+- imported entities in `import.yml` -> `import_entity`
+- auxiliary/raw transform file source -> `transform_source`
+- ambiguous match -> `None`
+
+**Acceptance criteria**
+
+- `occurrences.csv` resolves to `import_entity`
+- `raw_plot_stats.csv` resolves to `transform_source`
+- duplicate basename still returns `None`
+
+### Phase 2: Add `TransformSourceRegistry`
+
+Create a dedicated metadata store for transform-source schemas.
+
+Minimal API:
+
+```python
+class TransformSourceRegistry:
+    def get(self, source_name: str) -> TransformSourceMetadata | None: ...
+    def upsert(self, source_name: str, path: str, group_by: str | None, schema: dict) -> None: ...
+```
+
+**Persistence timing**
+
+Primary path:
+- after a successful transform run
+
+Optional backstop:
+- after explicit source configuration save if that flow already validates the file
+
+Do **not** update baseline during a failed compatibility check.
+
+**Acceptance criteria**
+
+- source baseline can be created in DuckDB metadata
+- re-reading the same source returns the previous schema
+- missing baseline returns `None`, not an error
+
+### Phase 3: Extend reference collection for transform sources
+
+Add the minimum missing coverage:
+
+1. `relation.match_field`
+2. `direct_attribute.params.field` when `params.source` matches the source name
+3. `field_aggregator.params.fields[*].field` when nested `source` matches the source name
+
+Implementation approach:
+
+- keep it explicit and limited
+- do not introduce generic recursive heuristics yet
+- build a small `TransformPluginRefsProviderV1_1`
+
+**Acceptance criteria**
+
+- `raw_plot_stats.csv` checks `match_field=plot_id`
+- `raw_shape_stats.csv` checks `match_field=label`
+- a `direct_attribute` referencing auxiliary source contributes a required field
+- a `field_aggregator` referencing auxiliary source contributes required fields
+
+### Phase 4: Add transform-source comparison semantics
+
+Update `ImpactAnalyzer` so the logic depends on target kind.
+
+For `transform_source`:
+
+- without baseline:
+  - report only missing referenced columns / unreadable file / path errors
+  - suppress opportunities
+- with baseline:
+  - compare referenced columns against old/new schema
+  - allow warnings on type drift
+  - keep opportunities optional and low-noise
+
+**Acceptance criteria**
+
+- identical re-upload of a known auxiliary source -> `0 impacts`
+- first-ever check of auxiliary source -> no spammy opportunities
+- missing `match_field` or plugin field -> `BREAKS_TRANSFORM`
+
+### Phase 5: Persist baseline after successful transform lifecycle
+
+Hook baseline persistence into the transform lifecycle.
+
+Preferred place:
+- `TransformerService`, after successful use/validation of a transform source
+
+Reason:
+- this keeps baseline aligned with a known-good pipeline state
+- avoids persisting speculative schemas from failed checks
+
+**Acceptance criteria**
+
+- successful transform run updates source baseline
+- failed transform run does not overwrite baseline
+
+### Phase 6: UI / CLI messaging adjustments
+
+Refine user-facing messages for transform sources:
+
+- `import_entity`: keep existing V1 language
+- `transform_source` with no baseline:
+  - "Required columns validated"
+  - "No previous baseline yet, so new-column opportunities are suppressed"
+
+This is important to avoid the impression that the check is inconsistent.
+
+**Acceptance criteria**
+
+- no long noisy opportunity list on first auxiliary-source check
+- user still sees missing required transform fields clearly
+
+## Testing Strategy
+
+### Unit tests
+
+- target resolution for `import_entity` vs `transform_source`
+- `TransformSourceRegistry` persistence
+- `match_field` collection
+- `direct_attribute` field collection
+- `field_aggregator` nested field collection
+- no-baseline suppression of opportunities
+
+### Integration tests
+
+Use real instance-style fixtures modeled on:
+
+- `test-instance/niamoto-subset`
+- `test-instance/niamoto-test2`
+
+Key regression cases:
+
+1. Re-upload identical `occurrences.csv` -> `0 impacts`
+2. Re-upload identical `plots.csv` -> `0 impacts`
+3. Re-upload identical `raw_plot_stats.csv` with baseline -> `0 impacts`
+4. First check of `raw_shape_stats.csv` without baseline -> no opportunity spam
+5. Remove `plot_id` from `raw_plot_stats.csv` -> `BREAKS_TRANSFORM`
+6. Remove `label` from `raw_shape_stats.csv` -> `BREAKS_TRANSFORM`
+
+## Risks and Guardrails
+
+- Keep all new logic in the compatibility/preflight layer.
+- Do not add special cases inside normal import execution for auxiliary sources.
+- Do not generalize plugin scanning beyond the two explicitly supported plugins in V1.1.
+- Do not emit `"opportunity"` findings for transform sources unless a baseline is known.
+- Treat this as a focused V1.1 hardening step, not as the full V2 plugin-aware system.
+
+## Success Criteria
+
+This plan is successful when:
+
+- imported entities still behave exactly like V1
+- auxiliary transform sources stop producing noisy false positives on identical re-upload
+- transform-critical missing fields are still reported
+- no changes are required to unrelated plugins
+- the design remains compatible with future V2 plugin-aware scanning
+
+## Recommended Delivery Order
+
+1. Phase 1 + Phase 2
+2. Phase 3 (`match_field`, `direct_attribute`, `field_aggregator`)
+3. Phase 4 comparison semantics
+4. Phase 5 persistence hook
+5. Phase 6 UX wording cleanup
+
+## References
+
+- [Brainstorm](/Users/julienbarbe/Dev/clients/niamoto/docs/brainstorms/2026-03-30-data-compatibility-check-brainstorm.md)
+- [V1 plan](/Users/julienbarbe/Dev/clients/niamoto/docs/plans/2026-03-30-feat-pre-import-impact-check-plan.md)
+- [Compatibility service](/Users/julienbarbe/Dev/clients/niamoto/src/niamoto/core/services/compatibility.py)
+- [DirectAttribute plugin](/Users/julienbarbe/Dev/clients/niamoto/src/niamoto/core/plugins/transformers/extraction/direct_attribute.py)
+- [FieldAggregator plugin](/Users/julienbarbe/Dev/clients/niamoto/src/niamoto/core/plugins/transformers/aggregation/field_aggregator.py)

--- a/docs/plans/2026-03-30-feat-pre-import-impact-check-gpkg-v2g1-plan.md
+++ b/docs/plans/2026-03-30-feat-pre-import-impact-check-gpkg-v2g1-plan.md
@@ -1,0 +1,306 @@
+# GPKG V2-G1 Implementation Plan
+
+## Goal
+
+Add **pre-import impact check support for simple `VECTOR` / GPKG connectors** in the
+preflight service, while keeping `FILE_MULTI_FEATURE` explicitly out of scope.
+
+This plan is a **small, isolated V2b slice**:
+
+- support `connector.type: vector`
+- keep `connector.type: file_multi_feature` as a skip
+- do not change runtime import behavior
+- do not mix GPKG work with plugin-aware reference work
+
+## Why This Is Separate
+
+The current impact-check service already has two independent complexity axes:
+
+1. **Reference coverage**: which columns are referenced by `transform.yml`
+2. **Schema readers**: how a source file schema is observed before import
+
+GPKG belongs to the second axis. It should be delivered independently from
+plugin-aware scanning so regressions remain attributable and the core service
+does not become a single large branching module.
+
+## Scope
+
+### In Scope
+
+- `VECTOR` connectors backed by a single `.gpkg` file
+- exact-match filename resolution for those connectors
+- native schema reading from SQLite / GeoPackage metadata
+- comparison of:
+  - attribute columns
+  - geometry column presence
+  - geometry type metadata
+- CLI and API returning a normal impact report instead of a skip
+
+### Out of Scope
+
+- `FILE_MULTI_FEATURE`
+- layer aggregation across multiple source files
+- CRS compatibility rules beyond lightweight metadata reporting
+- fuzzy resolver behavior
+- UI disambiguation
+- plugin-aware scanning changes
+
+## Current Behavior
+
+Today the compatibility service skips vector connectors in
+`src/niamoto/core/services/compatibility.py` with:
+
+- `VECTOR` → `"Not supported in V1 (GPKG)"`
+- `FILE_MULTI_FEATURE` → `"Not supported in V1 (multi-feature)"`
+
+This is correct for V1, but it prevents impact-check from helping on a normal
+single-file GeoPackage dataset or reference.
+
+## Product Behavior After V2-G1
+
+### Supported
+
+If the uploaded file matches a configured `VECTOR` connector:
+
+- the service resolves the entity
+- reads the GeoPackage schema
+- compares it with config references and registry context
+- returns a standard report with:
+  - missing required columns
+  - type changes on referenced fields
+  - geometry metadata warnings
+  - new columns as opportunities
+
+### Still Skipped
+
+If the uploaded file matches a `FILE_MULTI_FEATURE` connector:
+
+- keep returning a skip report
+- explicit message: `Not supported in V2-G1 (multi-feature)`
+
+This keeps the first GPKG slice small and avoids modeling a many-source entity
+as if it were one table.
+
+## Design
+
+### 1. Add a Schema Reader Abstraction
+
+Refactor the service toward a small reader registry:
+
+- `CSVSchemaReader`
+- `GPKGSchemaReader`
+
+Selection is based on connector type, not on file extension alone.
+
+Do not introduce a deep framework. A small internal dispatch method in the
+service is enough for V2-G1.
+
+### 2. GPKGSchemaReader
+
+Implement a reader that inspects the GeoPackage directly via SQLite metadata.
+
+Recommended sources:
+
+- `gpkg_contents`
+- `gpkg_geometry_columns`
+- `pragma table_info(<table>)`
+
+The reader should return an observed schema structure containing:
+
+- `fields`: list of `{name, type}`
+- `geometry_column`: optional string
+- `geometry_type`: optional string
+- `layer_name`: optional string
+
+### 3. Layer Resolution
+
+For V2-G1, layer resolution must stay conservative:
+
+1. If the connector explicitly provides a layer/table name, use it
+2. Otherwise:
+   - if the file contains exactly one feature table, use it
+   - if multiple feature tables exist, return an error asking for explicit layer configuration
+
+Do not guess between multiple layers.
+
+### 4. Comparison Semantics
+
+Extend the comparison model without changing its current spirit.
+
+#### Attribute columns
+
+Use the same rules as CSV:
+
+- missing referenced column → highest referenced severity
+- referenced type change → `WARNING`
+- new unreferenced column → `OPPORTUNITY`
+
+#### Geometry column
+
+Rules:
+
+- missing expected geometry column → `BLOCKS_IMPORT`
+- geometry column present but metadata differs from previous import → `WARNING`
+- geometry column present and unchanged → no issue
+
+#### Geometry type
+
+For V2-G1, geometry type differences should be a `WARNING`, not a blocker.
+
+Reason:
+
+- the preflight check can detect a change
+- but import/runtime compatibility depends on downstream behavior and is not yet
+  modeled precisely enough to justify a hard blocker
+
+### 5. Baseline / Registry Context
+
+For simple `VECTOR` entities, keep using `EntityRegistry` as the historical
+context source.
+
+Expected registry shape:
+
+- existing `schema.fields` for attribute columns
+- additive metadata for geometry information, for example:
+  - `schema.geometry_column`
+  - `schema.geometry_type`
+  - `schema.layer_name`
+
+This must be backward-compatible:
+
+- if old registry entries do not contain geometry metadata, comparison still works
+- only attribute comparison is enriched from the old schema
+
+### 6. Resolver
+
+Extend entity resolution to match `VECTOR` connector paths:
+
+- `connector.path` basename exact match
+
+Do not resolve `FILE_MULTI_FEATURE` source paths in this slice.
+
+## Implementation Phases
+
+### Phase 1: Reader + Data Model
+
+Files likely touched:
+
+- `src/niamoto/core/services/compatibility.py`
+
+Tasks:
+
+1. Introduce a light reader dispatch by connector type
+2. Add `GPKGSchemaReader`
+3. Extend observed schema shape to carry geometry metadata
+
+### Phase 2: Connector-Aware Resolution and Skip Rules
+
+Files likely touched:
+
+- `src/niamoto/core/services/compatibility.py`
+
+Tasks:
+
+1. Stop skipping `VECTOR`
+2. Keep skipping `FILE_MULTI_FEATURE`
+3. Extend resolver to match vector connector paths
+
+### Phase 3: Comparison Logic
+
+Files likely touched:
+
+- `src/niamoto/core/services/compatibility.py`
+
+Tasks:
+
+1. Compare attribute columns like CSV
+2. Add geometry column comparison
+3. Add geometry type warning logic
+
+### Phase 4: Tests
+
+Files likely touched:
+
+- `tests/core/services/test_compatibility.py`
+- optionally a dedicated fixture folder under `tests/data/`
+
+Tasks:
+
+1. Reader tests:
+   - single-layer GPKG
+   - multi-layer GPKG without explicit layer
+   - missing geometry metadata handling
+2. Service tests:
+   - vector entity identical file
+   - missing geometry column
+   - missing referenced attribute field
+   - geometry type changed → warning
+   - `FILE_MULTI_FEATURE` still skipped
+
+### Phase 5: Real-Instance Regression
+
+Use at least one real instance with single-file vector connectors to validate:
+
+- CLI `niamoto import check`
+- GUI/API `/imports/impact-check`
+
+## Acceptance Criteria
+
+### Functional
+
+- A simple `VECTOR` connector no longer returns a skip report
+- A `FILE_MULTI_FEATURE` connector still returns a skip report
+- Missing geometry column is detected
+- Missing referenced attribute columns are detected
+- Geometry type differences produce warnings, not blockers
+
+### Architectural
+
+- No runtime import logic is executed during preflight
+- No GPKG special cases are spread through unrelated service methods
+- Reader selection remains connector-driven and additive
+
+### UX
+
+- Existing CSV behavior is unchanged
+- Error message for ambiguous multi-layer GPKG is explicit
+- `FILE_MULTI_FEATURE` message remains clear that support is deferred
+
+## Risks
+
+### Main Risk
+
+Treating a GeoPackage as if it were always a single-table file.
+
+Mitigation:
+
+- explicit V2-G1 support only for simple `VECTOR`
+- explicit error when multiple feature tables exist and no layer is configured
+
+### Secondary Risk
+
+Mixing geometry metadata into the old CSV-centric schema shape too early.
+
+Mitigation:
+
+- keep geometry metadata additive and optional
+- do not force registry migration for existing entities
+
+## Follow-Up: V2-G2
+
+Once V2-G1 is stable, the next slice is:
+
+- `FILE_MULTI_FEATURE`
+- sub-report aggregation by source file / layer
+- optional per-source schema baseline
+
+That work should remain a separate plan and PR.
+
+## References
+
+- Main impact-check plan: `docs/plans/2026-03-30-feat-pre-import-impact-check-plan.md`
+- Brainstorm: `docs/brainstorms/2026-03-30-data-compatibility-check-brainstorm.md`
+- Compatibility service: `src/niamoto/core/services/compatibility.py`
+- Import config models: `src/niamoto/core/imports/config_models.py`
+- Existing vector/file-multi-feature examples:
+  - `test-instance/niamoto-test/config/import.yml`

--- a/docs/plans/2026-03-30-feat-pre-import-impact-check-plan.md
+++ b/docs/plans/2026-03-30-feat-pre-import-impact-check-plan.md
@@ -1,0 +1,662 @@
+---
+title: "feat: Pre-Import Impact Check V1"
+type: feat
+date: 2026-03-30
+brainstorm: docs/brainstorms/2026-03-30-data-compatibility-check-brainstorm.md
+---
+
+# feat: Pre-Import Impact Check V1
+
+## Overview
+
+When a user re-uploads source data (CSV), automatically analyze the new file against the existing pipeline configuration and show the **business impact** before importing. Not a schema diff — an impact check that tells the user what will break, what might break, and what's new.
+
+Design decisions are captured in the [approved brainstorm](../brainstorms/2026-03-30-data-compatibility-check-brainstorm.md). This plan covers V1 implementation only (CSV, coarse types, import.yml + transform.yml relation keys).
+
+## Problem Statement
+
+A user returns months later with updated data. They drop their new CSV on the Sources page and hit Import. If a column was renamed, removed, or changed type, the import succeeds but the transform pipeline silently breaks — bad charts, missing data, confusing errors downstream. There is no pre-flight check to warn them.
+
+## Proposed Solution
+
+A shared **CompatibilityService** (core layer) that:
+1. Reads the new CSV schema (reusing engine.py's CSV reading logic)
+2. Builds a config reference map from import.yml + transform.yml relation keys
+3. Compares against EntityRegistry metadata
+4. Produces an `ImpactReport` with severity-classified items
+
+Exposed via:
+- **CLI**: `niamoto import check` subcommand
+- **API**: `POST /api/imports/impact-check` (single endpoint: resolves entity + runs check)
+- **UI**: `CompatibilityPanel` in ImportWizard (between upload and import steps)
+
+## Technical Approach
+
+### Architecture
+
+```
+                    CompatibilityService (core)
+                   /           |            \
+          EntityResolver  ConfigRefCollector  CSVSchemaReader
+               |               |                    |
+         import.yml      import.yml +          engine._read_csv
+         connector.path  transform.yml          (reused logic)
+                         relation keys
+                               |
+                         ImpactReport
+                        /      |       \
+                    CLI       API      Frontend
+              (import check) (/impact-check) (CompatibilityPanel)
+```
+
+**Source of truth**: import.yml + transform.yml relation keys (config-first).
+**Context enrichment**: EntityRegistry `config["schema"]["fields"]` (what changed since last import).
+
+### Key Files to Create/Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/niamoto/core/services/compatibility.py` | **Create** | Core service: EntityResolver, ConfigRefCollector, CSVSchemaReader, ImpactAnalyzer |
+| `src/niamoto/cli/commands/imports.py` | Modify | Add `check` subcommand |
+| `src/niamoto/gui/api/routers/imports.py` | Modify | Add `/impact-check` endpoint |
+| `src/niamoto/gui/ui/src/features/import/components/CompatibilityPanel.tsx` | **Create** | Impact report UI component |
+| `src/niamoto/gui/ui/src/features/import/components/ImportWizard.tsx` | Modify | Add `checking` phase |
+| `src/niamoto/gui/ui/src/features/import/api/compatibility.ts` | **Create** | API client for compatibility endpoints |
+| `src/niamoto/gui/ui/src/features/import/hooks/useCompatibilityCheck.ts` | **Create** | Hook to trigger check after upload |
+| `tests/core/services/test_compatibility.py` | **Create** | Unit tests |
+| `tests/core/services/test_compatibility_integration.py` | **Create** | Integration tests with real CSV + config |
+| `tests/gui/api/routers/test_imports_compatibility.py` | **Create** | API endpoint tests |
+
+## Implementation Phases
+
+### Phase 1: Core Service — Config Reference Collector
+
+Build the module that parses import.yml and transform.yml to extract all column references with their impact levels.
+
+**`src/niamoto/core/services/compatibility.py`** — data models + config collector:
+
+```python
+# src/niamoto/core/services/compatibility.py
+
+from enum import Enum
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+import yaml
+
+from niamoto.core.imports.config_models import (
+    GenericImportConfig, ConnectorType, DatasetEntityConfig, ReferenceEntityConfig
+)
+from niamoto.common.transform_config_models import TransformGroupConfig
+
+
+class ImpactLevel(str, Enum):
+    BLOCKS_IMPORT = "blocks_import"
+    BREAKS_TRANSFORM = "breaks_transform"
+    WARNING = "warning"
+    OPPORTUNITY = "opportunity"
+
+
+@dataclass
+class ColumnMatch:
+    name: str
+    old_type: str
+    new_type: str
+
+
+@dataclass
+class ImpactItem:
+    column: str
+    level: ImpactLevel
+    detail: str
+    referenced_in: list[str] = field(default_factory=list)
+    old_type: Optional[str] = None
+    new_type: Optional[str] = None
+
+
+@dataclass
+class ImpactReport:
+    entity_name: str
+    file_path: str
+    matched_columns: list[ColumnMatch] = field(default_factory=list)
+    impacts: list[ImpactItem] = field(default_factory=list)
+    error: Optional[str] = None
+    skipped_reason: Optional[str] = None
+
+    @property
+    def has_blockers(self) -> bool:
+        return any(i.level == ImpactLevel.BLOCKS_IMPORT for i in self.impacts)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(
+            i.level in (ImpactLevel.BREAKS_TRANSFORM, ImpactLevel.WARNING)
+            for i in self.impacts
+        )
+
+    @property
+    def has_opportunities(self) -> bool:
+        return any(i.level == ImpactLevel.OPPORTUNITY for i in self.impacts)
+```
+
+```python
+# ConfigRefCollector — part of compatibility.py
+
+class ConfigRefCollector:
+    """Collect all column references from import.yml + transform.yml."""
+
+    def collect(
+        self, entity_name: str, import_config: dict, transform_config: list[dict]
+    ) -> dict[str, list[tuple[str, ImpactLevel]]]:
+        """Return {column_name: [(reference_path, impact_level), ...]}."""
+        refs: dict[str, list[tuple[str, ImpactLevel]]] = {}
+        self._collect_import_refs(entity_name, import_config, refs)
+        self._collect_transform_refs(entity_name, transform_config, refs)
+        return refs
+```
+
+**What `_collect_import_refs` scans** (all `BLOCKS_IMPORT` level):
+- `entities.datasets.{name}.schema.id_field`
+- `entities.datasets.{name}.schema.fields[].name`
+- `entities.datasets.{name}.links[].field` and `.target_field`
+- `entities.references.{name}.hierarchy.levels[].column`
+- `entities.references.{name}.connector.extraction.id_column`
+- `entities.references.{name}.connector.extraction.name_column`
+- `entities.references.{name}.connector.extraction.levels[].column`
+- `entities.references.{name}.connector.extraction.additional_columns`
+
+**What `_collect_transform_refs` scans** (all `BREAKS_TRANSFORM` level):
+
+Column attribution is **entity-aware** — each relation field references a column in a specific entity:
+- `sources[].relation.key` → column in the **data** entity (`sources[].data`)
+- `sources[].relation.ref_key` / `.ref_field` → column in the **grouping** entity (`sources[].grouping`)
+- `sources[].relation.fields` values → columns in the **grouping** entity
+
+So when checking entity `occurrences` (a dataset):
+- Scan groups where `sources[].data == "occurrences"` → collect `relation.key` (e.g. `id_taxonref`)
+- Do NOT collect `relation.ref_key` from those same sources (it belongs to the grouping entity)
+
+When checking entity `taxons` (a reference):
+- Scan groups where `sources[].grouping == "taxons"` → collect `relation.ref_key` (e.g. `taxons_id`), `relation.fields` values (e.g. `parent_id`, `lft`, `rght`)
+- Do NOT collect `relation.key` from those same sources (it belongs to the data entity)
+
+**Tests**: `tests/core/services/test_compatibility.py::TestConfigRefCollector`
+- [ ] Collects all import.yml column references for a dataset entity
+- [ ] Collects all import.yml column references for a reference entity (hierarchy + extraction)
+- [ ] Collects transform.yml relation keys for the correct entity
+- [ ] Handles missing import.yml gracefully (empty refs)
+- [ ] Handles missing transform.yml gracefully (empty refs)
+- [ ] Collects `relation.fields` mapping values (e.g. `parent_id`, `lft`, `rght`) as column references
+- [ ] Attributes `relation.key` to the data entity (not the grouping entity)
+- [ ] Attributes `relation.ref_key`/`ref_field`/`fields` to the grouping entity (not the data entity)
+- [ ] Does not scan transform.yml params (V2 scope)
+
+**Success criteria**: Given a real `import.yml` + `transform.yml` from `test-instance/niamoto-test/config/`, produce a complete reference map for `occurrences`.
+
+---
+
+### Phase 2: Core Service — CSV Schema Reader + Entity Resolver
+
+**CSV Schema Reader** — reuses `GenericImporter._read_csv` logic:
+
+```python
+# CSVSchemaReader — part of compatibility.py
+
+class CSVSchemaReader:
+    """Read CSV headers + sample, extract column names and coarse types."""
+
+    def read_schema(self, file_path: Path) -> tuple[list[dict], Optional[str]]:
+        """Return (fields: [{"name": str, "type": str}], error: Optional[str]).
+
+        Types align with engine.py _dtype_to_string: integer, float, boolean, datetime, string.
+        Reuses GenericImporter._read_csv for separator/encoding detection.
+        """
+```
+
+Key implementation detail: call `GenericImporter._read_csv(str(file_path), nrows=100)` to get a DataFrame, then iterate `df.dtypes` using the same `_dtype_to_string` mapping from `engine.py` (lines 777-786).
+
+**Entity Resolver** — conservative exact-match:
+
+```python
+# EntityResolver — part of compatibility.py
+
+class EntityResolver:
+    """Match uploaded filename to entity via import.yml connector.path."""
+
+    def resolve(self, filename: str, import_config: dict) -> Optional[str]:
+        """Return entity_name if exact basename match, None otherwise."""
+```
+
+Iterates over `import_config["entities"]["datasets"]` and `["references"]`, compares `Path(connector["path"]).name == filename`. If exactly one match → return entity name. If multiple matches (duplicate basename) → log a warning and return None (avoid silent false positive on the wrong entity). If no match → return None.
+
+**Tests**: `tests/core/services/test_compatibility.py::TestCSVSchemaReader`
+- [ ] Reads a simple CSV and returns correct column names and types
+- [ ] Handles semicolon separator (European CSV)
+- [ ] Handles latin-1 encoding
+- [ ] Returns error string for corrupt/unreadable file
+- [ ] Returns error string for empty file (0 bytes)
+- [ ] Returns columns with "string" types for header-only file (0 data rows — pandas infers `object`, mapped to `"string"` by `_dtype_to_string`)
+
+**Tests**: `tests/core/services/test_compatibility.py::TestEntityResolver`
+- [ ] Matches exact filename to dataset entity
+- [ ] Matches exact filename to reference entity
+- [ ] Returns None for non-matching filename
+- [ ] Returns None for empty import config
+- [ ] Skips DERIVED connector entities (no path to match)
+- [ ] Returns None and logs warning when multiple entities share the same basename (avoids false positive)
+
+---
+
+### Phase 3: Core Service — Impact Analyzer (orchestrator)
+
+The main `CompatibilityService` that orchestrates everything:
+
+```python
+# CompatibilityService — main orchestrator in compatibility.py
+
+class CompatibilityService:
+    """Pre-import impact check: analyze new CSV against existing pipeline config."""
+
+    def __init__(self, working_directory: Path):
+        self.working_directory = Path(working_directory)
+        self._resolver = EntityResolver()
+        self._collector = ConfigRefCollector()
+        self._reader = CSVSchemaReader()
+
+    def resolve_entity(self, filename: str) -> Optional[str]:
+        """Resolve filename to entity name via import.yml."""
+        import_config = self._load_import_config()
+        return self._resolver.resolve(filename, import_config)
+
+    def check_compatibility(self, entity_name: str, file_path: str) -> ImpactReport:
+        """Run full impact check for an entity against a new file."""
+```
+
+**`check_compatibility` flow** (called with a validated file path and a known FILE/DUCKDB_CSV entity):
+1. Resolve file path relative to working directory (security: reject paths outside project)
+2. Load import.yml + transform.yml configs
+3. Read new CSV schema via `CSVSchemaReader`
+4. Load existing schema from EntityRegistry `config["schema"]["fields"]` (opened with `read_only=True` to avoid contention with concurrent GUI operations)
+5. Collect config references via `ConfigRefCollector`
+6. Compare: for each referenced column, check if it exists in new schema → if not, create `ImpactItem` with appropriate level
+7. Compare types: for matched columns, check if type changed → create `WARNING` items
+8. Detect new columns: columns in new file not in config references or old schema → `OPPORTUNITY` items
+9. Return `ImpactReport`
+
+`check_compatibility` does NOT handle connector-type skipping — it assumes the caller has already filtered. This avoids the ambiguity of validating a file path that may not exist for non-file connectors.
+
+**`check_all` for CLI**:
+```python
+    def check_all(self, entity_filter: Optional[str] = None) -> list[ImpactReport]:
+        """Check all entities (or one) from import.yml against their source files."""
+```
+
+`check_all` short-circuits skipped connectors **before** calling `check_compatibility`:
+1. Load import.yml, iterate entities (filtered by `entity_filter` if set)
+2. For each entity, read `connector.type`:
+   - DERIVED → append skipped report ("Derived from {source} — check {source} instead")
+   - API/PLUGIN → append skipped report ("External connector — cannot check locally")
+   - VECTOR/FILE_MULTI_FEATURE → append skipped report ("Not supported in V1")
+   - FILE/DUCKDB_CSV → resolve `connector.path`, call `check_compatibility(entity_name, path)`
+3. Return all reports
+
+**Tests**: `tests/core/services/test_compatibility.py::TestCompatibilityService`
+- [ ] Produces correct ImpactReport for a CSV with all columns present (no issues)
+- [ ] Detects missing column referenced in import.yml → BLOCKS_IMPORT
+- [ ] Detects missing column referenced in transform.yml relation → BREAKS_TRANSFORM
+- [ ] Detects type change on existing column → WARNING
+- [ ] Detects new columns → OPPORTUNITY
+- [ ] Skips DERIVED entities with appropriate skipped_reason
+- [ ] Skips VECTOR entities (V2 scope)
+- [ ] Skips FILE_MULTI_FEATURE entities (V2 scope)
+- [ ] Skips API/PLUGIN entities with appropriate skipped_reason
+- [ ] Returns error report for unreadable file
+- [ ] Returns empty report when no config exists (first import)
+- [ ] Path validation: rejects paths outside working directory
+
+**Integration test**: `tests/core/services/test_compatibility_integration.py`
+- [ ] Run against `test-instance/niamoto-test/` with a modified CSV (removed column, added column, changed type)
+
+---
+
+### Phase 4: CLI Command
+
+Add `check` subcommand to the `import` group in `src/niamoto/cli/commands/imports.py`:
+
+```python
+# src/niamoto/cli/commands/imports.py — add after existing commands
+
+@import_commands.command(name="check")
+@click.option("--entity", "-e", default=None, help="Check a specific entity only")
+@error_handler(log=True, raise_error=True)
+def import_check(entity: str | None) -> None:
+    """Check compatibility between source files and current configuration."""
+    set_progress_mode(use_progress_bar=True)
+    config = Config()
+    project_root = Path(config.config_dir).parent  # config_dir = .../config/, parent = project root
+    service = CompatibilityService(project_root)
+    reports = service.check_all(entity_filter=entity)
+    _print_impact_reports(reports)
+    # Exit code 1 if any blockers or warnings
+    if any(r.has_blockers or r.has_warnings for r in reports):
+        raise SystemExit(1)
+```
+
+`_print_impact_reports` uses Click's `click.style()` for color-coded output:
+- Red: BLOCKS_IMPORT items
+- Yellow/orange: BREAKS_TRANSFORM items
+- Yellow: WARNING items
+- Cyan: OPPORTUNITY items
+- Green: entity with no issues
+- Gray: skipped entities (DERIVED, etc.)
+
+**Tests**: `tests/cli/commands/test_imports.py` (extend existing)
+- [ ] `niamoto import check` runs without error on test instance
+- [ ] `niamoto import check --entity occurrences` checks single entity
+- [ ] Exit code 0 when no issues
+- [ ] Exit code 1 when issues found
+
+---
+
+### Phase 5: API Endpoint
+
+Single endpoint in `src/niamoto/gui/api/routers/imports.py` — resolves entity internally then runs check. Simpler frontend orchestration (one call instead of two):
+
+```python
+# Pydantic models — add to imports.py
+
+class ImpactCheckRequest(BaseModel):
+    file_path: str  # relative to project root, e.g. "imports/occurrences.csv"
+
+class ImpactItemResponse(BaseModel):
+    column: str
+    level: str  # ImpactLevel value
+    detail: str
+    referenced_in: list[str]
+    old_type: Optional[str] = None
+    new_type: Optional[str] = None
+
+class ColumnMatchResponse(BaseModel):
+    name: str
+    old_type: str
+    new_type: str
+
+class ImpactCheckResponse(BaseModel):
+    # Entity resolution result
+    entity_name: Optional[str] = None  # None if no match
+    # Impact report (only present if entity matched)
+    matched_columns: list[ColumnMatchResponse] = []
+    impacts: list[ImpactItemResponse] = []
+    error: Optional[str] = None
+    skipped_reason: Optional[str] = None
+    has_blockers: bool = False
+    has_warnings: bool = False
+    has_opportunities: bool = False
+```
+
+**`POST /api/imports/impact-check`**:
+```python
+@router.post("/impact-check", response_model=ImpactCheckResponse)
+async def impact_check(request: ImpactCheckRequest):
+    work_dir = get_working_directory()
+    # Path validation FIRST — reject paths outside project before any processing
+    resolved = (work_dir / request.file_path).resolve()
+    if not resolved.is_relative_to(work_dir.resolve()):
+        raise HTTPException(status_code=400, detail="Path outside project directory")
+    service = CompatibilityService(work_dir)
+    filename = Path(request.file_path).name
+    entity_name = service.resolve_entity(filename)
+    if entity_name is None:
+        return ImpactCheckResponse()  # no match, all defaults
+    report = service.check_compatibility(entity_name, request.file_path)
+    return ImpactCheckResponse(
+        entity_name=report.entity_name,
+        matched_columns=[...],
+        impacts=[...],
+        error=report.error,
+        skipped_reason=report.skipped_reason,
+        has_blockers=report.has_blockers,
+        has_warnings=report.has_warnings,
+        has_opportunities=report.has_opportunities,
+    )
+```
+
+**Tests**: `tests/gui/api/routers/test_imports_compatibility.py`
+- [ ] POST `/impact-check` resolves entity and returns ImpactReport for known file
+- [ ] POST `/impact-check` returns empty response (entity_name=null) for unknown file
+- [ ] POST `/impact-check` handles missing entity gracefully
+- [ ] POST `/impact-check` rejects paths outside project with 400 (security — validated before any processing)
+- [ ] POST `/impact-check` returns entity_name=null when filename does not match any FILE/DUCKDB_CSV entity
+
+---
+
+### Phase 6: Frontend — CompatibilityPanel + ImportWizard Integration
+
+#### 6a. API Client
+
+**`src/niamoto/gui/ui/src/features/import/api/compatibility.ts`**:
+
+```typescript
+import { apiClient } from '@/shared/lib/api/client';
+
+export interface ImpactItem {
+  column: string;
+  level: 'blocks_import' | 'breaks_transform' | 'warning' | 'opportunity';
+  detail: string;
+  referenced_in: string[];
+  old_type?: string;
+  new_type?: string;
+}
+
+export interface ImpactCheckResult {
+  entity_name: string | null;
+  matched_columns: { name: string; old_type: string; new_type: string }[];
+  impacts: ImpactItem[];
+  error?: string;
+  skipped_reason?: string;
+  has_blockers: boolean;
+  has_warnings: boolean;
+  has_opportunities: boolean;
+}
+
+export async function impactCheck(filePath: string): Promise<ImpactCheckResult> {
+  const { data } = await apiClient.post('/imports/impact-check', { file_path: filePath });
+  return data;
+}
+```
+
+#### 6b. Hook
+
+**`src/niamoto/gui/ui/src/features/import/hooks/useCompatibilityCheck.ts`**:
+
+React Query mutation hook. After upload completes:
+1. For each uploaded file, call `impactCheck(filePath)` — single API call per file
+2. Backend resolves entity internally and runs check
+3. Filter results: only keep reports where `entity_name` is not null (matched files)
+4. Return `{ matched: ImpactCheckResult[], unmatched: string[] }`
+
+#### 6c. CompatibilityPanel Component
+
+**`src/niamoto/gui/ui/src/features/import/components/CompatibilityPanel.tsx`**:
+
+- Receives `reports: ImpactCheckResult[]` as prop (same type defined in `compatibility.ts`)
+- Groups impacts by level (blockers first, then breaks, then warnings, then opportunities)
+- Color scheme: red / orange / yellow / blue
+- Each impact shows: column name, detail text, where it's referenced
+- Matched columns shown as a collapsed summary ("12 columns OK")
+- No DERIVED entities shown in UI (they have no source file to upload — DERIVED skips are only relevant in CLI's `check_all`)
+- Actions: **"Continue anyway"** button + **"Fix data"** link (back to upload)
+
+#### 6d. ImportWizard Integration
+
+**`src/niamoto/gui/ui/src/features/import/components/ImportWizard.tsx`**:
+
+**Critical flow decision**: The compatibility check runs **BEFORE** auto-configure, not after. Auto-configure generates a new config from the uploaded files, so checking after would compare the file against its own freshly-generated config (meaningless). The check only makes sense against the **pre-existing** config.
+
+**New flow for re-upload scenario** (existing entities detected):
+```
+upload complete
+  → POST /impact-check for each file (single call per file)
+  → files where entity_name != null: have impact reports → phase 'checking' → CompatibilityPanel
+  → files where entity_name == null: queued for auto-configure
+  → user clicks "Continue anyway"
+  → proceed to auto-configure (phase 'configuring') for all files → 'reviewing'
+```
+
+**New flow for first-time upload** (no match):
+```
+upload complete
+  → POST /impact-check returns entity_name=null for all files
+  → skip check entirely
+  → proceed to auto-configure (phase 'configuring') → 'reviewing' (unchanged)
+```
+
+Implementation steps:
+1. Add `'checking'` to `ImportPhase` type union
+2. After upload completes (`handleFilesReady`), call the compatibility check hook **before** calling `runAutoConfigure`
+3. Hook calls `POST /impact-check` for each uploaded file (single API call per file, backend resolves entity internally)
+4. If any results have `entity_name` != null → set phase to `'checking'`, render CompatibilityPanel
+5. If all results have `entity_name` == null → skip directly to `runAutoConfigure` (existing flow)
+6. "Continue anyway" → proceed to `runAutoConfigure` then `'configuring'` → `'reviewing'`
+7. "Fix data" → keep uploaded files in state, return to upload zone so user can replace specific files (do NOT reset everything with `resetToIdle()`)
+
+**Multi-file behavior**: When some files match entities and others don't:
+- CompatibilityPanel shows one report per matched file
+- Unmatched files are listed separately ("New files — will be auto-configured")
+- "Continue anyway" proceeds with ALL files (matched + unmatched)
+
+**Loading state**: While `/impact-check` calls are in progress, show a "Checking compatibility..." message with spinner (similar to `configuring` phase animation).
+
+**Error handling**: If `/impact-check` API calls fail, silently skip the check and proceed to auto-configure (non-blocking philosophy).
+
+**DB access**: CompatibilityService opens EntityRegistry in `read_only=True` mode to avoid contention with concurrent operations in the long-running FastAPI process.
+
+**UI acceptance criteria**:
+- [ ] Panel appears automatically after re-upload when entity is recognized
+- [ ] Panel does NOT appear on first-time upload (no existing config)
+- [ ] Check runs BEFORE auto-configure, not after
+- [ ] Impact items are grouped and color-coded by severity
+- [ ] Matched columns shown collapsed
+- [ ] "Continue anyway" proceeds to auto-configure then review/import flow
+- [ ] "Fix data" returns to upload zone (keeps file list, does not reset everything)
+- [ ] DERIVED entities never appear in UI (no file to match — only shown in CLI `check_all`)
+- [ ] Multi-file: shows reports for matched files, lists unmatched files separately
+- [ ] Loading spinner shown while checking
+- [ ] API errors silently skip the check (non-blocking)
+
+---
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] `niamoto import check` CLI command works and reports impact for all entities
+- [ ] `niamoto import check --entity occurrences` works for single entity
+- [ ] CLI exit code 0 when clean, 1 when issues found
+- [ ] `POST /api/imports/impact-check` resolves entity + returns ImpactReport JSON in one call
+- [ ] ImportWizard shows CompatibilityPanel after re-upload with impact data
+- [ ] DERIVED entities: skipped with info message in CLI `check_all`, not surfaced in UI (no file to match)
+- [ ] First import (no config) does not show panel
+- [ ] Missing columns classified as BLOCKS_IMPORT or BREAKS_TRANSFORM
+- [ ] Type changes classified as WARNING
+- [ ] New columns classified as OPPORTUNITY
+- [ ] Non-blocking: user can always proceed to import
+
+### Non-Functional
+
+- [ ] Check completes in < 2 seconds for typical CSV (< 50 columns, < 100k rows sampled)
+- [ ] No hardcoded entity or field names (genericity rule)
+- [ ] Path validation rejects files outside project directory
+- [ ] CSV reading uses same logic as engine.py (no check/import divergence)
+
+### Quality Gates
+
+- [ ] Unit tests for ConfigRefCollector, CSVSchemaReader, EntityResolver, CompatibilityService
+- [ ] Integration test against test-instance config
+- [ ] API endpoint tests
+- [ ] `uvx ruff check src/` passes
+- [ ] `uvx ruff format src/` passes
+- [ ] `uv run pytest` passes
+- [ ] `cd src/niamoto/gui/ui && pnpm build` passes (required for any GUI work)
+
+## Dependencies & Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `_read_csv` is not easily callable from outside engine.py (may be tightly coupled) | Extract separator/encoding detection into a shared utility, or call `_read_csv` as a static method |
+| transform.yml `params` contains column references not covered by V1 | Documented as V2 scope — V1 checks relation keys only |
+| EntityRegistry may not have `schema.fields` for old imports (pre-feature) | Fall back to empty old schema — all columns show as "new" |
+| YAML `!include` directives in config files | V1 limitation: parse raw YAML only, document the gap |
+
+## V2 Roadmap (out of scope)
+
+Three independent workstreams, ordered by priority:
+
+### Critical guardrails
+
+- Keep V2 logic in the **preflight compatibility service**, not in the import
+  runtime. Extending `CompatibilityService` is acceptable; pushing V2 logic into
+  `GenericImporter` or normal import execution paths is not.
+- Do **not** deliver V2 as one large milestone or PR. Ship `V2a`, `V2b`, and
+  `V2c` independently to contain risk and keep regressions attributable.
+- Avoid heuristic "magic" in reference detection. If a plugin param is treated as
+  a column reference, that contract must be explicit in plugin metadata or a
+  dedicated hook.
+- Prefer additive extension points over more branching in the core service:
+  new `RefsProvider`s, new `SchemaReader`s, and a small reader/provider registry.
+
+### V2a: Extensible reference coverage (highest priority)
+
+Closes the main logic gap — transform.yml `params` column references are not checked.
+This is the **highest complexity / fragility risk** in V2 because it increases
+coupling with the plugin ecosystem.
+
+1. **Plugin-aware param scanning** via explicit contract: each plugin's Pydantic
+   `config_model` declares which fields are column references (metadata on fields
+   or a `collect_column_refs(config)` hook). No heuristic name scanning.
+   Leverage existing `config_model` in `base.py` and per-plugin models like
+   `stats_loader.py`.
+2. Refactor collectors into composable providers:
+   - `ImportRefsProvider` (already implemented)
+   - `TransformRelationRefsProvider` (already implemented)
+   - `PluginParamRefsProvider` (new)
+3. Keep plugin-aware scanning read-only and preflight-only. It must not require
+   loading or executing transformer/widget logic to determine references.
+
+### V2b: Extensible schema readers
+
+Moderate risk if isolated behind a reader interface; high risk if implemented as
+special cases scattered through the core service.
+
+1. **GPKGSchemaReader** — native schema from SQLite metadata (`pragma table_info`)
+2. **MultiFeatureSchemaReader** — check each source file, aggregate sub-reports
+3. Reader selection by connector type (registry pattern)
+
+For the first bounded delivery of this track, see:
+`docs/plans/2026-03-30-feat-pre-import-impact-check-gpkg-v2g1-plan.md`
+
+### V2c: Resolver UX
+
+Low technical risk. Keep the resolver conservative: exact-match resolution plus
+explicit disambiguation UI.
+
+1. **Disambiguation UI** — dropdown when multiple entities share the same filename
+2. No fuzzy/stem matching (too risky for false positives)
+
+### Future (V3+)
+
+- Impact severity based on downstream widget usage (requires solid reference
+  coverage first)
+
+## References
+
+- **Brainstorm**: `docs/brainstorms/2026-03-30-data-compatibility-check-brainstorm.md`
+- **Import engine**: `src/niamoto/core/imports/engine.py` (CSV reading: lines 506-558, type mapping: lines 777-786, metadata: lines 576-607)
+- **EntityRegistry**: `src/niamoto/core/imports/registry.py` (EntityMetadata: line 23, config JSON structure)
+- **Import config models**: `src/niamoto/core/imports/config_models.py` (ConnectorConfig: line 43, LinkConfig: line 215, ExtractionConfig: line 133)
+- **Transform config models**: `src/niamoto/common/transform_config_models.py` (TransformRelationConfig: line 10, TransformSourceConfig: line 22)
+- **CLI imports group**: `src/niamoto/cli/commands/imports.py` (Click group: line 26)
+- **API imports router**: `src/niamoto/gui/api/routers/imports.py` (router registration in app.py: line 86)
+- **ImportWizard**: `src/niamoto/gui/ui/src/features/import/components/ImportWizard.tsx` (phases: line 39, upload flow: line 477)
+- **Service pattern**: `src/niamoto/core/services/importer.py` (constructor: lines 37-41)
+- **API context**: `src/niamoto/gui/api/context.py` (`get_working_directory()`)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,6 +39,7 @@ Daily development workflow scripts.
 | `bench_preview.py` | Benchmark preview engine (P50/P95/P99 latency) |
 | `bench_pipeline.py` | Benchmark sequential `transform` and `export` on a staged instance |
 | `evaluate_pipeline.py` | Diagnostic tool for data profiling + suggestions |
+| `run_import_check_lab.py` | Run a regression matrix for impact-check lab scenarios |
 
 **Common usage:**
 ```bash
@@ -53,6 +54,9 @@ uv run python scripts/dev/bench_preview.py --base-url http://localhost:8000
 
 # Benchmark transform/export on niamoto-subset
 uv run python scripts/dev/bench_pipeline.py --instance test-instance/niamoto-subset
+
+# Run the impact-check regression lab on niamoto-subset
+uv run python scripts/dev/run_import_check_lab.py --instance test-instance/niamoto-subset
 
 # Evaluate suggestion pipeline on a CSV
 uv run python scripts/dev/evaluate_pipeline.py path/to/data.csv

--- a/scripts/dev/run_import_check_lab.py
+++ b/scripts/dev/run_import_check_lab.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Run a regression matrix for pre-import impact-check lab scenarios.
+
+Usage:
+    uv run python scripts/dev/run_import_check_lab.py
+    uv run python scripts/dev/run_import_check_lab.py --instance test-instance/niamoto-subset
+    uv run python scripts/dev/run_import_check_lab.py --only plot_stats_missing_id
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from niamoto.core.services.compatibility import CompatibilityService
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    passed: bool
+    summary: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run import-check regression scenarios against an instance lab."
+    )
+    parser.add_argument(
+        "--instance",
+        default="test-instance/niamoto-subset",
+        help="Instance root relative to repo root or absolute path.",
+    )
+    parser.add_argument(
+        "--lab",
+        default=None,
+        help="Lab directory relative to the instance root. Defaults to import-check-lab.",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help="Manifest YAML path. Defaults to <lab>/expectations.yml.",
+    )
+    parser.add_argument(
+        "--only",
+        action="append",
+        default=[],
+        help="Run only matching case id(s). Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def resolve_path(raw: str | None, *, base: Path) -> Path | None:
+    if raw is None:
+        return None
+    path = Path(raw)
+    if not path.is_absolute():
+        path = base / path
+    return path.resolve()
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Manifest must be a mapping: {path}")
+    if not isinstance(data.get("cases"), list):
+        raise ValueError(f"Manifest must contain a 'cases' list: {path}")
+    return data
+
+
+def impact_pairs(report) -> list[tuple[str, str]]:
+    return sorted((item.level.value, item.column) for item in report.impacts)
+
+
+def evaluate_expectation(report: Any, expect: dict[str, Any]) -> list[str]:
+    actual_pairs = impact_pairs(report)
+    expected_pairs = sorted(
+        (str(item["level"]), str(item["column"])) for item in expect.get("impacts", [])
+    )
+
+    failures: list[str] = []
+
+    if "matched_columns" in expect:
+        expected_matched = int(expect["matched_columns"])
+        if len(report.matched_columns) != expected_matched:
+            failures.append(
+                f"matched={len(report.matched_columns)} expected={expected_matched}"
+            )
+
+    if actual_pairs != expected_pairs:
+        failures.append(f"impacts={actual_pairs} expected={expected_pairs}")
+
+    expected_error = expect.get("error")
+    actual_error = report.error
+    if expected_error is None:
+        if actual_error is not None:
+            failures.append(f"error={actual_error!r} expected=None")
+    elif actual_error != expected_error:
+        failures.append(f"error={actual_error!r} expected={expected_error!r}")
+
+    expected_info = expect.get("info_message_contains")
+    actual_info = report.info_message
+    if expected_info is None:
+        if actual_info is not None:
+            failures.append(f"info={actual_info!r} expected=None")
+    elif not actual_info or str(expected_info) not in actual_info:
+        failures.append(f"info={actual_info!r} expected_contains={expected_info!r}")
+
+    expected_skip = expect.get("skipped_reason_contains")
+    actual_skip = report.skipped_reason
+    if expected_skip is None:
+        if actual_skip is not None:
+            failures.append(f"skip={actual_skip!r} expected=None")
+    elif not actual_skip or str(expected_skip) not in actual_skip:
+        failures.append(f"skip={actual_skip!r} expected_contains={expected_skip!r}")
+
+    return failures
+
+
+def evaluate_case(service: CompatibilityService, case: dict[str, Any]) -> CaseResult:
+    case_id = str(case["id"])
+    entity = str(case["entity"])
+    file_path = str(case["file"])
+
+    report = service.check_compatibility(entity, file_path)
+    expectations = case.get("expect_any")
+    if expectations is None:
+        expectations = [case.get("expect", {}) or {}]
+
+    failure_sets = [
+        evaluate_expectation(report, expect or {}) for expect in expectations
+    ]
+    if any(not failures for failures in failure_sets):
+        note = case.get("note")
+        if note:
+            return CaseResult(case_id=case_id, passed=True, summary=f"ok ({note})")
+        return CaseResult(case_id=case_id, passed=True, summary="ok")
+
+    flattened = " || ".join(" | ".join(failures) for failures in failure_sets)
+    return CaseResult(case_id=case_id, passed=False, summary=flattened)
+
+
+def main() -> int:
+    from niamoto.core.services.compatibility import CompatibilityService
+
+    args = parse_args()
+
+    instance = resolve_path(args.instance, base=REPO_ROOT)
+    if instance is None or not instance.exists():
+        print(f"Instance not found: {args.instance}", file=sys.stderr)
+        return 2
+
+    lab = (
+        resolve_path(args.lab, base=instance)
+        if args.lab
+        else (instance / "import-check-lab").resolve()
+    )
+    manifest = (
+        resolve_path(args.manifest, base=REPO_ROOT)
+        if args.manifest
+        else (lab / "expectations.yml").resolve()
+    )
+
+    if manifest is None or not manifest.exists():
+        print(f"Manifest not found: {manifest}", file=sys.stderr)
+        return 2
+
+    data = load_manifest(manifest)
+    cases = data["cases"]
+    if args.only:
+        wanted = set(args.only)
+        cases = [case for case in cases if str(case["id"]) in wanted]
+
+    if not cases:
+        print("No cases selected.")
+        return 1
+
+    service = CompatibilityService(instance)
+    results = [evaluate_case(service, case) for case in cases]
+
+    print(f"\nImport-check lab: {manifest}\n")
+    width = max(len(result.case_id) for result in results)
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        print(f"{status:<4}  {result.case_id:<{width}}  {result.summary}")
+
+    failed = [result for result in results if not result.passed]
+    print(f"\nSummary: {len(results) - len(failed)}/{len(results)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/niamoto/cli/commands/imports.py
+++ b/src/niamoto/cli/commands/imports.py
@@ -245,6 +245,100 @@ def import_list() -> None:
         raise
 
 
+@import_commands.command(name="check")
+@click.option("--entity", "-e", default=None, help="Check a specific entity only")
+@error_handler(log=True, raise_error=True)
+def import_check(entity=None):
+    """Check compatibility between source files and current configuration.
+
+    Compares each source CSV against import.yml + transform.yml to detect
+    missing columns, type changes, and new columns before importing.
+
+    \b
+    Examples:
+        niamoto import check
+        niamoto import check --entity occurrences
+    """
+    from pathlib import Path
+
+    from niamoto.core.services.compatibility import CompatibilityService, ImpactLevel
+
+    set_progress_mode(use_progress_bar=True)
+    config = Config()
+    project_root = Path(config.config_dir).parent
+    service = CompatibilityService(project_root)
+    reports = service.check_all(entity_filter=entity)
+
+    if not reports:
+        print_info("No entities found in import.yml")
+        return
+
+    has_issues = False
+    for report in reports:
+        name = report.entity_name
+        if report.skipped_reason:
+            click.echo(
+                click.style(f"  {name}: ", fg="white", dim=True)
+                + click.style(report.skipped_reason, dim=True)
+            )
+            continue
+        if report.error:
+            click.echo(
+                click.style(f"  {name}: ", fg="red")
+                + click.style(report.error, fg="red")
+            )
+            has_issues = True
+            continue
+        if report.info_message and not report.impacts:
+            click.echo(
+                click.style(f"  {name}: ", fg="blue")
+                + click.style(report.info_message, dim=True)
+            )
+            continue
+
+        blockers = [i for i in report.impacts if i.level == ImpactLevel.BLOCKS_IMPORT]
+        breaks = [i for i in report.impacts if i.level == ImpactLevel.BREAKS_TRANSFORM]
+        warnings = [i for i in report.impacts if i.level == ImpactLevel.WARNING]
+        opportunities = [
+            i for i in report.impacts if i.level == ImpactLevel.OPPORTUNITY
+        ]
+
+        if not report.impacts:
+            n = len(report.matched_columns)
+            click.echo(click.style(f"  {name}: ", fg="green") + f"{n} columns OK")
+            continue
+
+        has_issues = has_issues or bool(blockers or breaks or warnings)
+        click.echo(click.style(f"\n  {name}:", bold=True))
+        n = len(report.matched_columns)
+        if n:
+            click.echo(click.style(f"    {n} columns OK", fg="green"))
+        for item in blockers:
+            click.echo(
+                click.style("    BLOCKS IMPORT: ", fg="red")
+                + f"{item.column} — {item.detail}"
+            )
+            for ref in item.referenced_in:
+                click.echo(click.style(f"      -> {ref}", dim=True))
+        for item in breaks:
+            click.echo(
+                click.style("    BREAKS TRANSFORM: ", fg="yellow")
+                + f"{item.column} — {item.detail}"
+            )
+            for ref in item.referenced_in:
+                click.echo(click.style(f"      -> {ref}", dim=True))
+        for item in warnings:
+            click.echo(
+                click.style("    WARNING: ", fg="yellow")
+                + f"{item.column} — {item.detail}"
+            )
+        for item in opportunities:
+            click.echo(click.style("    NEW: ", fg="cyan") + f"{item.column}")
+
+    if has_issues:
+        raise SystemExit(1)
+
+
 # Keep compatibility alias for `niamoto import all` → `niamoto import run`
 @import_commands.command(name="all", hidden=True)
 @click.option(

--- a/src/niamoto/core/imports/source_registry.py
+++ b/src/niamoto/core/imports/source_registry.py
@@ -1,0 +1,174 @@
+"""Registry storing observed schemas for transform-only file sources."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from niamoto.common.database import Database
+from niamoto.common.exceptions import DatabaseQueryError
+
+
+class TransformSourceMetadata(BaseModel):
+    """Metadata stored for a transform-only file source."""
+
+    name: str
+    path: str
+    grouping: str
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class TransformSourceRegistry:
+    """Persist observed schemas for auxiliary transform CSV sources."""
+
+    SOURCES_TABLE = "niamoto_metadata_transform_sources"
+
+    def __init__(self, db: Database) -> None:
+        self.db = db
+        self._ensure_tables()
+
+    def register_source(
+        self,
+        *,
+        name: str,
+        path: str,
+        grouping: str,
+        config: Dict[str, Any],
+    ) -> None:
+        """Upsert metadata for a transform source."""
+
+        payload = json.dumps(config, ensure_ascii=False)
+        sql = f"""
+            INSERT OR REPLACE INTO {self.SOURCES_TABLE} (name, path, grouping, config)
+            VALUES (:name, :path, :grouping, :config)
+        """
+        self.db.execute_sql(
+            sql,
+            {
+                "name": name,
+                "path": path,
+                "grouping": grouping,
+                "config": payload,
+            },
+        )
+
+    def get(self, name: str) -> TransformSourceMetadata:
+        """Return metadata for one transform source."""
+
+        sql = f"""
+            SELECT name, path, grouping, config
+            FROM {self.SOURCES_TABLE}
+            WHERE name = :name
+        """
+        row = self.db.execute_sql(sql, {"name": name}, fetch=True)
+        if row is None:
+            raise DatabaseQueryError(
+                query="transform_source_lookup",
+                message="Transform source not found",
+                details={"name": name},
+            )
+        return self._row_to_metadata(row)
+
+    def list_sources(self) -> List[TransformSourceMetadata]:
+        """Return all registered transform sources."""
+
+        sql = f"SELECT name, path, grouping, config FROM {self.SOURCES_TABLE}"
+        try:
+            rows = self.db.execute_sql(sql, fetch_all=True)
+        except DatabaseQueryError:
+            return []
+        if not rows:
+            return []
+        return [self._row_to_metadata(row) for row in rows]
+
+    def _ensure_tables(self) -> None:
+        create_sources = f"""
+            CREATE TABLE IF NOT EXISTS {self.SOURCES_TABLE} (
+                name TEXT PRIMARY KEY,
+                path TEXT NOT NULL,
+                grouping TEXT NOT NULL,
+                config TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """
+        if getattr(self.db, "read_only", False):
+            return
+        self.db.execute_sql(create_sources)
+
+    def _row_to_metadata(self, row: Any) -> TransformSourceMetadata:
+        """Normalize a database row into source metadata."""
+
+        name: Optional[str] = None
+        path: Optional[str] = None
+        grouping: Optional[str] = None
+        payload: Any = None
+
+        if hasattr(row, "_mapping"):
+            mapping = row._mapping
+            name = mapping.get("name")
+            path = mapping.get("path")
+            grouping = mapping.get("grouping")
+            payload = mapping.get("config")
+        elif isinstance(row, Mapping):
+            name = row.get("name")
+            path = row.get("path")
+            grouping = row.get("grouping")
+            payload = row.get("config")
+        elif isinstance(row, Sequence) and not isinstance(row, (str, bytes, bytearray)):
+            if len(row) < 4:
+                raise DatabaseQueryError(
+                    query="transform_source_lookup",
+                    message="Transform source row has unexpected length",
+                    details={"row": list(row)},
+                )
+            name, path, grouping, payload = row[:4]
+        else:
+            raise DatabaseQueryError(
+                query="transform_source_lookup",
+                message="Unsupported transform source row format",
+                details={"row": str(row)},
+            )
+
+        if not isinstance(name, str) or not name:
+            raise DatabaseQueryError(
+                query="transform_source_lookup",
+                message="Invalid transform source name",
+                details={"name": name},
+            )
+        if not isinstance(path, str) or not path:
+            raise DatabaseQueryError(
+                query="transform_source_lookup",
+                message="Invalid transform source path",
+                details={"path": path},
+            )
+        if not isinstance(grouping, str) or not grouping:
+            raise DatabaseQueryError(
+                query="transform_source_lookup",
+                message="Invalid transform source grouping",
+                details={"grouping": grouping},
+            )
+
+        if isinstance(payload, str):
+            try:
+                config_dict = json.loads(payload)
+            except (json.JSONDecodeError, ValueError) as exc:
+                raise DatabaseQueryError(
+                    query="transform_source_lookup",
+                    message="Invalid JSON in transform source config",
+                    details={"config": payload, "error": str(exc)},
+                )
+        elif isinstance(payload, Mapping):
+            config_dict = dict(payload)
+        else:
+            config_dict = {}
+
+        return TransformSourceMetadata(
+            name=name,
+            path=path,
+            grouping=grouping,
+            config=config_dict,
+        )

--- a/src/niamoto/core/services/compatibility.py
+++ b/src/niamoto/core/services/compatibility.py
@@ -1,0 +1,1364 @@
+"""Pre-import impact check: analyze new CSV against existing pipeline config.
+
+Compares a new source file schema against the columns referenced in
+import.yml and transform.yml to report what will break, what might break,
+and what is new.  Config is the source of truth; the EntityRegistry provides
+context about what changed since the last import.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import yaml
+
+from niamoto.core.imports.config_models import ConnectorType
+from niamoto.core.imports.engine import GenericImporter
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class ImpactLevel(str, Enum):
+    BLOCKS_IMPORT = "blocks_import"
+    BREAKS_TRANSFORM = "breaks_transform"
+    WARNING = "warning"
+    OPPORTUNITY = "opportunity"
+
+
+class TargetKind(str, Enum):
+    IMPORT_ENTITY = "import_entity"
+    TRANSFORM_SOURCE = "transform_source"
+
+
+@dataclass
+class ColumnMatch:
+    name: str
+    old_type: str
+    new_type: str
+
+
+@dataclass
+class ImpactItem:
+    column: str
+    level: ImpactLevel
+    detail: str
+    referenced_in: list[str] = field(default_factory=list)
+    old_type: Optional[str] = None
+    new_type: Optional[str] = None
+
+
+@dataclass
+class ImpactReport:
+    entity_name: str
+    file_path: str
+    matched_columns: list[ColumnMatch] = field(default_factory=list)
+    impacts: list[ImpactItem] = field(default_factory=list)
+    error: Optional[str] = None
+    skipped_reason: Optional[str] = None
+    info_message: Optional[str] = None
+
+    @property
+    def has_blockers(self) -> bool:
+        return any(i.level == ImpactLevel.BLOCKS_IMPORT for i in self.impacts)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(
+            i.level in (ImpactLevel.BREAKS_TRANSFORM, ImpactLevel.WARNING)
+            for i in self.impacts
+        )
+
+    @property
+    def has_opportunities(self) -> bool:
+        return any(i.level == ImpactLevel.OPPORTUNITY for i in self.impacts)
+
+
+# ---------------------------------------------------------------------------
+# Reference type alias:  {column: [(path, level), ...]}
+# ---------------------------------------------------------------------------
+
+ColumnRefMap = Dict[str, List[Tuple[str, ImpactLevel]]]
+
+
+# ---------------------------------------------------------------------------
+# Config Reference Collector
+# ---------------------------------------------------------------------------
+
+
+class ConfigRefCollector:
+    """Collect every column referenced in import.yml + transform.yml."""
+
+    CLASS_OBJECT_STRUCTURAL_COLUMNS: Dict[str, Tuple[str, ...]] = {
+        "class_object_series_extractor": ("class_object",),
+        "class_object_field_aggregator": ("class_object", "class_value"),
+        "class_object_categories_extractor": (
+            "class_object",
+            "class_name",
+            "class_value",
+        ),
+        "class_object_binary_aggregator": (
+            "class_object",
+            "class_name",
+            "class_value",
+        ),
+        "class_object_series_ratio_aggregator": (
+            "class_object",
+            "class_name",
+            "class_value",
+        ),
+        "class_object_series_matrix_extractor": ("class_object", "class_value"),
+        "class_object_series_by_axis_extractor": ("class_object", "class_value"),
+        "class_object_categories_mapper": (
+            "class_object",
+            "class_name",
+            "class_value",
+        ),
+    }
+    SIMPLE_SOURCE_FIELD_PLUGINS: Dict[str, Tuple[str, ...]] = {
+        "top_ranking": ("field", "aggregate_field"),
+        "binned_distribution": ("field",),
+        "binary_counter": ("field",),
+        "statistical_summary": ("field",),
+        "categorical_distribution": ("field",),
+        "geospatial_extractor": ("field",),
+        "shape_processor": ("field",),
+    }
+    GROUP_WIDGET_FIELD_PLUGINS: Dict[str, Tuple[str, ...]] = {
+        "hierarchical_nav_widget": (
+            "id_field",
+            "name_field",
+            "parent_id_field",
+            "lft_field",
+            "rght_field",
+            "level_field",
+            "group_by_field",
+            "group_by_label_field",
+        ),
+        "entity_map_extractor": (
+            "geometry_field",
+            "name_field",
+            "id_field",
+        ),
+    }
+
+    def collect(
+        self,
+        entity_name: str,
+        import_config: dict,
+        transform_config: list[dict],
+    ) -> ColumnRefMap:
+        refs: ColumnRefMap = {}
+        self._collect_import_refs(entity_name, import_config, refs)
+        self._collect_auxiliary_source_refs(entity_name, import_config, refs)
+        self._collect_transform_refs(entity_name, transform_config, refs)
+        return refs
+
+    # -- import.yml ----------------------------------------------------------
+
+    def _collect_import_refs(
+        self,
+        entity_name: str,
+        import_config: dict,
+        refs: ColumnRefMap,
+    ) -> None:
+        entities = import_config.get("entities", {})
+        datasets = entities.get("datasets", {})
+        references = entities.get("references", {})
+
+        if entity_name in datasets:
+            self._collect_dataset_refs(entity_name, datasets[entity_name], refs)
+            # Also collect extraction columns from DERIVED references that
+            # depend on this dataset — removing those columns from the source
+            # CSV would break the derived reference build.
+            for ref_name, ref_cfg in references.items():
+                connector = ref_cfg.get("connector", {})
+                if (
+                    connector.get("type") == ConnectorType.DERIVED.value
+                    and connector.get("source") == entity_name
+                ):
+                    extraction = connector.get("extraction", {})
+                    self._collect_extraction_refs(
+                        entity_name, ref_name, extraction, refs
+                    )
+        elif entity_name in references:
+            self._collect_reference_refs(entity_name, references[entity_name], refs)
+
+    def _collect_auxiliary_source_refs(
+        self,
+        entity_name: str,
+        import_config: dict,
+        refs: ColumnRefMap,
+    ) -> None:
+        for source in import_config.get("auxiliary_sources", []) or []:
+            source_name = source.get("name", "")
+            data_entity = source.get("data", "")
+            grouping_entity = source.get("grouping", "")
+            relation = source.get("relation", {})
+            prefix = f"import.yml > auxiliary_sources > {source_name}"
+            self._collect_source_relation_refs(
+                entity_name=entity_name,
+                source_name=source_name,
+                data_entity=data_entity,
+                grouping_entity=grouping_entity,
+                relation=relation,
+                prefix=prefix,
+                refs=refs,
+            )
+
+    def _collect_dataset_refs(
+        self, entity_name: str, cfg: dict, refs: ColumnRefMap
+    ) -> None:
+        prefix = f"import.yml > {entity_name}"
+        schema = cfg.get("schema", {})
+
+        # id_field
+        id_field = schema.get("id_field") or schema.get("id")
+        if id_field:
+            self._add(
+                refs, id_field, f"{prefix} > schema.id_field", ImpactLevel.BLOCKS_IMPORT
+            )
+
+        # fields
+        for f in schema.get("fields", []):
+            name = f.get("name") if isinstance(f, dict) else f
+            if name:
+                self._add(
+                    refs, name, f"{prefix} > schema.fields", ImpactLevel.BLOCKS_IMPORT
+                )
+
+        # links
+        for link in cfg.get("links", []):
+            if link.get("field"):
+                self._add(
+                    refs,
+                    link["field"],
+                    f"{prefix} > links > field",
+                    ImpactLevel.BLOCKS_IMPORT,
+                )
+            if link.get("target_field"):
+                self._add(
+                    refs,
+                    link["target_field"],
+                    f"{prefix} > links > target_field",
+                    ImpactLevel.BLOCKS_IMPORT,
+                )
+
+    def _collect_reference_refs(
+        self, entity_name: str, cfg: dict, refs: ColumnRefMap
+    ) -> None:
+        prefix = f"import.yml > {entity_name}"
+        schema = cfg.get("schema", {})
+
+        # id_field
+        id_field = schema.get("id_field") or schema.get("id")
+        if id_field:
+            self._add(
+                refs, id_field, f"{prefix} > schema.id_field", ImpactLevel.BLOCKS_IMPORT
+            )
+
+        # fields
+        for f in schema.get("fields", []):
+            name = f.get("name") if isinstance(f, dict) else f
+            if name:
+                self._add(
+                    refs, name, f"{prefix} > schema.fields", ImpactLevel.BLOCKS_IMPORT
+                )
+
+        # hierarchy levels
+        hierarchy = cfg.get("hierarchy", {})
+        for level in hierarchy.get("levels", []):
+            col = level.get("column") if isinstance(level, dict) else level
+            if col:
+                self._add(
+                    refs,
+                    col,
+                    f"{prefix} > hierarchy > {level.get('name', col) if isinstance(level, dict) else col}",
+                    ImpactLevel.BLOCKS_IMPORT,
+                )
+
+        # extraction (for DERIVED — columns in the *source* dataset)
+        connector = cfg.get("connector", {})
+        extraction = connector.get("extraction", {})
+        if extraction:
+            self._collect_extraction_refs(entity_name, entity_name, extraction, refs)
+
+    def _collect_extraction_refs(
+        self,
+        source_entity: str,
+        ref_name: str,
+        extraction: dict,
+        refs: ColumnRefMap,
+    ) -> None:
+        """Collect columns from a DERIVED extraction config.
+
+        These columns exist in the source dataset and are needed to build
+        the derived reference.  Called both when checking the reference itself
+        and when checking the source dataset it depends on.
+        """
+        prefix = f"import.yml > {ref_name} > extraction"
+        for lvl in extraction.get("levels", []):
+            col = lvl.get("column") if isinstance(lvl, dict) else lvl
+            if col:
+                lvl_name = lvl.get("name", col) if isinstance(lvl, dict) else col
+                self._add(
+                    refs,
+                    col,
+                    f"{prefix} > levels > {lvl_name}",
+                    ImpactLevel.BLOCKS_IMPORT,
+                )
+        if extraction.get("id_column"):
+            self._add(
+                refs,
+                extraction["id_column"],
+                f"{prefix} > id_column",
+                ImpactLevel.BLOCKS_IMPORT,
+            )
+        if extraction.get("name_column"):
+            self._add(
+                refs,
+                extraction["name_column"],
+                f"{prefix} > name_column",
+                ImpactLevel.BLOCKS_IMPORT,
+            )
+        for col in extraction.get("additional_columns", []):
+            self._add(
+                refs,
+                col,
+                f"{prefix} > additional_columns",
+                ImpactLevel.BLOCKS_IMPORT,
+            )
+
+    # -- transform.yml -------------------------------------------------------
+
+    def _collect_transform_refs(
+        self,
+        entity_name: str,
+        transform_config: list[dict],
+        refs: ColumnRefMap,
+    ) -> None:
+        for group in transform_config:
+            group_by = group.get("group_by", "")
+            matched_widget_sources: set[str] = set()
+            for source in group.get("sources", []):
+                data_entity = source.get("data", "")
+                grouping_entity = source.get("grouping", "")
+                relation = source.get("relation", {})
+                source_name = source.get("name", "")
+                prefix = f"transform.yml > group {group_by} > source {source_name}"
+                self._collect_source_relation_refs(
+                    entity_name=entity_name,
+                    source_name=source_name,
+                    data_entity=data_entity,
+                    grouping_entity=grouping_entity,
+                    relation=relation,
+                    prefix=prefix,
+                    refs=refs,
+                )
+                if self._is_source_match(entity_name, source_name, data_entity):
+                    matched_widget_sources.add(source_name)
+                    if data_entity:
+                        matched_widget_sources.add(data_entity)
+                        if "/" in data_entity:
+                            matched_widget_sources.add(Path(data_entity).stem)
+
+            if group_by == entity_name:
+                matched_widget_sources.add(entity_name)
+                self._collect_group_widget_refs(
+                    entity_name=entity_name,
+                    group=group,
+                    refs=refs,
+                )
+
+            for source_name in matched_widget_sources:
+                self._collect_widget_source_refs(
+                    source_name=source_name,
+                    group=group,
+                    refs=refs,
+                )
+
+    def _collect_source_relation_refs(
+        self,
+        *,
+        entity_name: str,
+        source_name: str,
+        data_entity: str,
+        grouping_entity: str,
+        relation: dict,
+        prefix: str,
+        refs: ColumnRefMap,
+    ) -> None:
+        is_data_match = self._is_source_match(entity_name, source_name, data_entity)
+
+        if is_data_match and relation.get("key"):
+            self._add(
+                refs,
+                relation["key"],
+                f"{prefix} > relation.key",
+                ImpactLevel.BREAKS_TRANSFORM,
+            )
+        if is_data_match and relation.get("match_field"):
+            self._add(
+                refs,
+                relation["match_field"],
+                f"{prefix} > relation.match_field",
+                ImpactLevel.BREAKS_TRANSFORM,
+            )
+
+        if grouping_entity == entity_name:
+            if relation.get("ref_key"):
+                self._add(
+                    refs,
+                    relation["ref_key"],
+                    f"{prefix} > relation.ref_key",
+                    ImpactLevel.BREAKS_TRANSFORM,
+                )
+            if relation.get("ref_field"):
+                self._add(
+                    refs,
+                    relation["ref_field"],
+                    f"{prefix} > relation.ref_field",
+                    ImpactLevel.BREAKS_TRANSFORM,
+                )
+            for key, col in (relation.get("fields") or {}).items():
+                self._add(
+                    refs,
+                    col,
+                    f"{prefix} > relation.fields.{key}",
+                    ImpactLevel.BREAKS_TRANSFORM,
+                )
+
+    def _collect_widget_source_refs(
+        self,
+        *,
+        source_name: str,
+        group: dict,
+        refs: ColumnRefMap,
+    ) -> None:
+        group_by = group.get("group_by", "")
+        widgets = group.get("widgets_data", {})
+        for widget_name, widget_cfg in widgets.items():
+            plugin_name = widget_cfg.get("plugin", "")
+            params = widget_cfg.get("params", {}) or {}
+            prefix = f"transform.yml > group {group_by} > widgets_data > {widget_name}"
+
+            if plugin_name == "direct_attribute":
+                widget_source = widget_cfg.get("source") or params.get("source")
+                widget_field = widget_cfg.get("field") or params.get("field")
+                if widget_source == source_name and widget_field:
+                    self._add(
+                        refs,
+                        widget_field,
+                        f"{prefix} > params.field",
+                        ImpactLevel.BREAKS_TRANSFORM,
+                    )
+
+            if plugin_name == "field_aggregator":
+                for index, field_cfg in enumerate(params.get("fields") or []):
+                    if (
+                        isinstance(field_cfg, dict)
+                        and field_cfg.get("source") == source_name
+                        and field_cfg.get("field")
+                    ):
+                        self._add(
+                            refs,
+                            field_cfg["field"],
+                            f"{prefix} > params.fields[{index}].field",
+                            ImpactLevel.BREAKS_TRANSFORM,
+                        )
+
+            self._collect_simple_widget_refs(
+                source_name=source_name,
+                plugin_name=plugin_name,
+                params=params,
+                prefix=prefix,
+                refs=refs,
+            )
+            self._collect_time_series_widget_refs(
+                source_name=source_name,
+                plugin_name=plugin_name,
+                params=params,
+                prefix=prefix,
+                refs=refs,
+            )
+            self._collect_top_ranking_widget_refs(
+                source_name=source_name,
+                current_entity=source_name,
+                plugin_name=plugin_name,
+                params=params,
+                prefix=prefix,
+                refs=refs,
+            )
+            self._collect_geospatial_widget_refs(
+                source_name=source_name,
+                plugin_name=plugin_name,
+                params=params,
+                prefix=prefix,
+                refs=refs,
+            )
+            self._collect_class_object_widget_refs(
+                source_name=source_name,
+                plugin_name=plugin_name,
+                params=params,
+                prefix=prefix,
+                refs=refs,
+            )
+
+    def _collect_group_widget_refs(
+        self,
+        *,
+        entity_name: str,
+        group: dict,
+        refs: ColumnRefMap,
+    ) -> None:
+        group_by = group.get("group_by", "")
+        widgets = group.get("widgets_data", {})
+        for widget_name, widget_cfg in widgets.items():
+            plugin_name = widget_cfg.get("plugin", "")
+            params = widget_cfg.get("params", {}) or {}
+            fields = self.GROUP_WIDGET_FIELD_PLUGINS.get(plugin_name)
+            if not fields:
+                continue
+            referential_data = params.get("referential_data")
+            prefix = f"transform.yml > group {group_by} > widgets_data > {widget_name}"
+            if plugin_name == "hierarchical_nav_widget":
+                if referential_data != entity_name or group_by != entity_name:
+                    continue
+            elif plugin_name == "entity_map_extractor":
+                entity_table = str(params.get("entity_table", "") or "")
+                if not self._matches_entity_table(entity_name, entity_table):
+                    continue
+            else:
+                continue
+            for field_name in fields:
+                column = params.get(field_name)
+                if column:
+                    self._add(
+                        refs,
+                        column,
+                        f"{prefix} > params.{field_name}",
+                        ImpactLevel.BREAKS_TRANSFORM,
+                    )
+
+    def _collect_simple_widget_refs(
+        self,
+        *,
+        source_name: str,
+        plugin_name: str,
+        params: dict,
+        prefix: str,
+        refs: ColumnRefMap,
+    ) -> None:
+        fields = self.SIMPLE_SOURCE_FIELD_PLUGINS.get(plugin_name)
+        if not fields:
+            return
+        if params.get("source") != source_name:
+            return
+        for field_name in fields:
+            column = params.get(field_name)
+            if column:
+                self._add(
+                    refs,
+                    column,
+                    f"{prefix} > params.{field_name}",
+                    ImpactLevel.BREAKS_TRANSFORM,
+                )
+
+    def _collect_time_series_widget_refs(
+        self,
+        *,
+        source_name: str,
+        plugin_name: str,
+        params: dict,
+        prefix: str,
+        refs: ColumnRefMap,
+    ) -> None:
+        if plugin_name != "time_series_analysis":
+            return
+        if params.get("source") != source_name:
+            return
+
+        for field_name in ("field", "time_field"):
+            column = params.get(field_name)
+            if column:
+                self._add(
+                    refs,
+                    column,
+                    f"{prefix} > params.{field_name}",
+                    ImpactLevel.BREAKS_TRANSFORM,
+                )
+
+        for key, column in (params.get("fields") or {}).items():
+            if column:
+                self._add(
+                    refs,
+                    column,
+                    f"{prefix} > params.fields.{key}",
+                    ImpactLevel.BREAKS_TRANSFORM,
+                )
+
+    def _collect_top_ranking_widget_refs(
+        self,
+        *,
+        source_name: str,
+        current_entity: str,
+        plugin_name: str,
+        params: dict,
+        prefix: str,
+        refs: ColumnRefMap,
+    ) -> None:
+        if plugin_name != "top_ranking":
+            return
+
+        widget_source = params.get("source")
+        mode = params.get("mode", "direct")
+        if widget_source == source_name:
+            for field_name in ("field", "aggregate_field"):
+                column = params.get(field_name)
+                if column:
+                    self._add(
+                        refs,
+                        column,
+                        f"{prefix} > params.{field_name}",
+                        ImpactLevel.BREAKS_TRANSFORM,
+                    )
+
+        hierarchy_table = params.get("hierarchy_table")
+        if hierarchy_table == current_entity and mode in {
+            "hierarchical",
+            "join",
+            "direct",
+        }:
+            hierarchy_columns = params.get("hierarchy_columns") or {}
+            for field_name in ("id", "name", "rank", "parent_id", "left", "right"):
+                column = hierarchy_columns.get(field_name)
+                if column:
+                    self._add(
+                        refs,
+                        column,
+                        f"{prefix} > params.hierarchy_columns.{field_name}",
+                        ImpactLevel.BREAKS_TRANSFORM,
+                    )
+
+        join_table = params.get("join_table")
+        if join_table == current_entity and mode == "join":
+            join_columns = params.get("join_columns") or {}
+            for field_name in ("source_id", "target_id", "hierarchy_id"):
+                column = join_columns.get(field_name)
+                if column:
+                    self._add(
+                        refs,
+                        column,
+                        f"{prefix} > params.join_columns.{field_name}",
+                        ImpactLevel.BREAKS_TRANSFORM,
+                    )
+
+    def _collect_geospatial_widget_refs(
+        self,
+        *,
+        source_name: str,
+        plugin_name: str,
+        params: dict,
+        prefix: str,
+        refs: ColumnRefMap,
+    ) -> None:
+        if plugin_name != "geospatial_extractor":
+            return
+        if params.get("source") != source_name:
+            return
+
+        for field_name in ("field",):
+            column = params.get(field_name)
+            if column:
+                self._add(
+                    refs,
+                    column,
+                    f"{prefix} > params.{field_name}",
+                    ImpactLevel.BREAKS_TRANSFORM,
+                )
+
+        for field_name in ("properties", "children_properties"):
+            for index, column in enumerate(params.get(field_name) or []):
+                if column:
+                    self._add(
+                        refs,
+                        column,
+                        f"{prefix} > params.{field_name}[{index}]",
+                        ImpactLevel.BREAKS_TRANSFORM,
+                    )
+
+        hierarchy_config = params.get("hierarchy_config") or {}
+        for field_name in (
+            "type_field",
+            "parent_field",
+            "left_field",
+            "right_field",
+        ):
+            column = hierarchy_config.get(field_name)
+            if column:
+                self._add(
+                    refs,
+                    column,
+                    f"{prefix} > params.hierarchy_config.{field_name}",
+                    ImpactLevel.BREAKS_TRANSFORM,
+                )
+
+    def _collect_class_object_widget_refs(
+        self,
+        *,
+        source_name: str,
+        plugin_name: str,
+        params: dict,
+        prefix: str,
+        refs: ColumnRefMap,
+    ) -> None:
+        structural_columns = self.CLASS_OBJECT_STRUCTURAL_COLUMNS.get(plugin_name)
+        if not structural_columns:
+            return
+
+        if plugin_name == "class_object_field_aggregator":
+            for index, field_cfg in enumerate(params.get("fields") or []):
+                if not isinstance(field_cfg, dict):
+                    continue
+                field_source = field_cfg.get("source") or params.get("source")
+                if field_source != source_name:
+                    continue
+                self._add_required_columns(
+                    refs=refs,
+                    columns=structural_columns,
+                    path_prefix=f"{prefix} > params.fields[{index}]",
+                )
+            return
+
+        widget_source = params.get("source")
+        if widget_source != source_name:
+            return
+
+        self._add_required_columns(
+            refs=refs,
+            columns=structural_columns,
+            path_prefix=f"{prefix} > data",
+        )
+
+        if plugin_name == "class_object_series_extractor":
+            for field_name in ("size_field", "value_field"):
+                field_cfg = params.get(field_name) or {}
+                input_column = field_cfg.get("input")
+                if input_column:
+                    self._add(
+                        refs,
+                        input_column,
+                        f"{prefix} > params.{field_name}.input",
+                        ImpactLevel.BREAKS_TRANSFORM,
+                    )
+
+        if plugin_name in {
+            "class_object_series_matrix_extractor",
+            "class_object_series_by_axis_extractor",
+        }:
+            axis_field = (params.get("axis") or {}).get("field")
+            if axis_field:
+                self._add(
+                    refs,
+                    axis_field,
+                    f"{prefix} > params.axis.field",
+                    ImpactLevel.BREAKS_TRANSFORM,
+                )
+
+    def _add_required_columns(
+        self,
+        *,
+        refs: ColumnRefMap,
+        columns: Tuple[str, ...],
+        path_prefix: str,
+    ) -> None:
+        for column in columns:
+            self._add(
+                refs,
+                column,
+                f"{path_prefix}.{column}",
+                ImpactLevel.BREAKS_TRANSFORM,
+            )
+
+    @staticmethod
+    def _is_source_match(entity_name: str, source_name: str, data_entity: str) -> bool:
+        return (
+            data_entity == entity_name
+            or source_name == entity_name
+            or ("/" in data_entity and Path(data_entity).stem == entity_name)
+        )
+
+    @staticmethod
+    def _is_transform_source_match(
+        entity_name: str, source_name: str, data_entity: str
+    ) -> bool:
+        return "/" in data_entity and (
+            source_name == entity_name or Path(data_entity).stem == entity_name
+        )
+
+    @staticmethod
+    def _matches_entity_table(entity_name: str, entity_table: str) -> bool:
+        if not entity_table:
+            return False
+        normalized = entity_table
+        for prefix in ("entity_", "dataset_", "reference_"):
+            if normalized.startswith(prefix):
+                normalized = normalized[len(prefix) :]
+                break
+        return normalized == entity_name
+
+    # -- helpers -------------------------------------------------------------
+
+    @staticmethod
+    def _add(
+        refs: ColumnRefMap,
+        column: str,
+        path: str,
+        level: ImpactLevel,
+    ) -> None:
+        refs.setdefault(column, []).append((path, level))
+
+
+# ---------------------------------------------------------------------------
+# CSV Schema Reader
+# ---------------------------------------------------------------------------
+
+
+class CSVSchemaReader:
+    """Read CSV headers + sample, extract column names and coarse types."""
+
+    @staticmethod
+    def read_schema(
+        file_path: Path,
+    ) -> Tuple[List[Dict[str, str]], Optional[str]]:
+        """Return (fields, error).
+
+        ``fields`` is a list of ``{"name": str, "type": str}`` aligned with
+        the coarse types persisted by ``engine.py._dtype_to_string``.
+        """
+        try:
+            df = GenericImporter._read_csv(file_path, nrows=100)
+        except Exception as exc:  # noqa: BLE001
+            return [], str(exc)
+
+        fields: List[Dict[str, str]] = []
+        for col in df.columns:
+            if df[col].notna().sum() == 0:
+                inferred_type = "unknown"
+            else:
+                inferred_type = GenericImporter._dtype_to_string(df[col].dtype)
+            fields.append(
+                {
+                    "name": str(col),
+                    "type": inferred_type,
+                }
+            )
+        return fields, None
+
+
+# ---------------------------------------------------------------------------
+# Entity Resolver
+# ---------------------------------------------------------------------------
+
+
+class EntityResolver:
+    """Match an uploaded filename to an entity or transform source."""
+
+    @staticmethod
+    def resolve(
+        filename: str,
+        import_config: dict,
+        transform_config: Optional[list[dict]] = None,
+    ) -> Optional[str]:
+        """Return entity/source name if exactly one basename match, else None.
+
+        Scans both import.yml connector paths and transform.yml
+        ``sources[].data`` values that are file paths (not entity names).
+        """
+        entities = import_config.get("entities", {})
+        matches: list[str] = []
+
+        # 1. import.yml connector paths
+        for section in ("datasets", "references"):
+            for name, cfg in entities.get(section, {}).items():
+                connector = cfg.get("connector", {})
+                ctype = connector.get("type", "")
+                if ctype in (
+                    ConnectorType.DERIVED.value,
+                    ConnectorType.API.value,
+                    ConnectorType.PLUGIN.value,
+                ):
+                    continue
+                path = connector.get("path")
+                if path and Path(path).name == filename:
+                    matches.append(name)
+
+        # 1b. import.yml auxiliary_sources
+        for source in import_config.get("auxiliary_sources", []) or []:
+            path = source.get("data", "")
+            source_name = source.get("name", "")
+            if path and Path(path).name == filename and source_name not in matches:
+                matches.append(source_name)
+
+        # 2. transform.yml sources[].data that are file paths (contain /)
+        for group in transform_config or []:
+            for source in group.get("sources", []):
+                data = source.get("data", "")
+                if "/" in data and Path(data).name == filename:
+                    source_name = source.get("name", data)
+                    if source_name not in matches:
+                        matches.append(source_name)
+
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            logger.warning(
+                "Ambiguous entity match for '%s': %s — skipping check",
+                filename,
+                matches,
+            )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Compatibility Service (orchestrator)
+# ---------------------------------------------------------------------------
+
+
+class CompatibilityService:
+    """Pre-import impact check: analyse new CSV against existing pipeline config."""
+
+    _TYPELESS_SAMPLE_TYPES = {"unknown"}
+    _SKIPPABLE_CONNECTORS = {
+        ConnectorType.DERIVED.value: "Derived entity — check the source dataset instead",
+        ConnectorType.API.value: "External connector — cannot check locally",
+        ConnectorType.PLUGIN.value: "External connector — cannot check locally",
+        ConnectorType.VECTOR.value: "Not supported in V1 (GPKG)",
+        ConnectorType.FILE_MULTI_FEATURE.value: "Not supported in V1 (multi-feature)",
+    }
+
+    def __init__(self, working_directory: Path) -> None:
+        self.working_directory = Path(working_directory)
+        self._resolver = EntityResolver()
+        self._collector = ConfigRefCollector()
+        self._reader = CSVSchemaReader()
+
+    # -- public API ----------------------------------------------------------
+
+    def resolve_entity(self, filename: str) -> Optional[str]:
+        """Resolve filename to entity/source name via import.yml + transform.yml."""
+        import_config = self._load_import_config()
+        transform_config = self._load_transform_config()
+        return self._resolver.resolve(filename, import_config, transform_config)
+
+    def check_compatibility(self, entity_name: str, file_path: str) -> ImpactReport:
+        """Run full impact check for an entity against a new file.
+
+        Checks connector type and returns a skip report for non-CSV
+        connectors (VECTOR, FILE_MULTI_FEATURE, etc.).
+        """
+        # 1. Resolve & validate path
+        resolved = (self.working_directory / file_path).resolve()
+        if not resolved.is_relative_to(self.working_directory.resolve()):
+            return ImpactReport(
+                entity_name=entity_name,
+                file_path=file_path,
+                error="Path outside project directory",
+            )
+
+        # 2. Load configs
+        import_config = self._load_import_config()
+        transform_config = self._load_transform_config()
+        target_kind = self._resolve_target_kind(
+            entity_name, import_config, transform_config
+        )
+
+        # 2b. Check connector type — skip non-CSV connectors
+        skip_reason = self._get_skip_reason(entity_name, import_config)
+        if skip_reason:
+            return ImpactReport(
+                entity_name=entity_name,
+                file_path=file_path,
+                skipped_reason=skip_reason,
+            )
+
+        # 3. Read new CSV schema
+        new_fields, read_error = self._reader.read_schema(resolved)
+        if read_error:
+            return ImpactReport(
+                entity_name=entity_name,
+                file_path=file_path,
+                error=read_error,
+            )
+
+        new_schema = {f["name"]: f["type"] for f in new_fields}
+
+        # 4. Load old schema from registry (context, not truth)
+        old_schema = self._load_old_schema(
+            entity_name, target_kind, import_config, transform_config
+        )
+        info_message = None
+        if target_kind == TargetKind.TRANSFORM_SOURCE and not old_schema:
+            info_message = (
+                "First check for auxiliary source — validating required columns only "
+                "until a transform run records a schema baseline"
+            )
+
+        # 5. Collect config references (source of truth)
+        config_refs = self._collector.collect(
+            entity_name, import_config, transform_config
+        )
+
+        # 6-9. Compare and produce report
+        return self._compare(
+            entity_name,
+            file_path,
+            new_schema,
+            old_schema,
+            config_refs,
+            target_kind=target_kind,
+            info_message=info_message,
+        )
+
+    def check_all(self, entity_filter: Optional[str] = None) -> list[ImpactReport]:
+        """Check all entities (or one) from import.yml against their source files."""
+        import_config = self._load_import_config()
+        transform_config = self._load_transform_config()
+        reports: list[ImpactReport] = []
+
+        entities = import_config.get("entities", {})
+        for section in ("datasets", "references"):
+            for name, cfg in entities.get(section, {}).items():
+                if entity_filter and name != entity_filter:
+                    continue
+                connector = cfg.get("connector", {})
+
+                # Short-circuit skippable connectors
+                skip_reason = self._get_skip_reason(name, import_config)
+                if skip_reason:
+                    reports.append(
+                        ImpactReport(
+                            entity_name=name,
+                            file_path="",
+                            skipped_reason=skip_reason,
+                        )
+                    )
+                    continue
+
+                # FILE / DUCKDB_CSV
+                path = connector.get("path", "")
+                if not path:
+                    reports.append(
+                        ImpactReport(
+                            entity_name=name,
+                            file_path="",
+                            error="No source path configured",
+                        )
+                    )
+                    continue
+
+                reports.append(self.check_compatibility(name, path))
+
+        for source in self._list_transform_sources(import_config, transform_config):
+            name = source.get("name", "")
+            path = source.get("path", "")
+            if not name or not path:
+                continue
+            if entity_filter and name != entity_filter:
+                continue
+            reports.append(self.check_compatibility(name, path))
+
+        return reports
+
+    # -- private helpers -----------------------------------------------------
+
+    def _get_skip_reason(self, entity_name: str, import_config: dict) -> Optional[str]:
+        """Return a skip reason if the entity's connector is not checkable, else None."""
+        entities = import_config.get("entities", {})
+        for section in ("datasets", "references"):
+            cfg = entities.get(section, {}).get(entity_name)
+            if cfg:
+                ctype = cfg.get("connector", {}).get("type", "")
+                reason = self._SKIPPABLE_CONNECTORS.get(ctype)
+                if reason and ctype == ConnectorType.DERIVED.value:
+                    source = cfg.get("connector", {}).get("source", "?")
+                    return f"Derived from {source} — check {source} instead"
+                return reason
+        return None  # Not in import.yml — could be a transform-only CSV source
+
+    def _load_import_config(self) -> dict:
+        path = self.working_directory / "config" / "import.yml"
+        if not path.exists():
+            return {"entities": {"datasets": {}, "references": {}}}
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        return data if isinstance(data, dict) else {}
+
+    def _load_transform_config(self) -> list[dict]:
+        path = self.working_directory / "config" / "transform.yml"
+        if not path.exists():
+            return []
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or []
+        return data if isinstance(data, list) else []
+
+    def _load_old_schema(
+        self,
+        entity_name: str,
+        target_kind: TargetKind,
+        import_config: dict,
+        transform_config: list[dict],
+    ) -> dict[str, str]:
+        if target_kind == TargetKind.TRANSFORM_SOURCE:
+            source = self._find_transform_source(
+                entity_name, import_config, transform_config
+            )
+            if not source:
+                return {}
+            return self._load_transform_source_schema(source["name"])
+        return self._load_registry_schema(entity_name)
+
+    def _load_registry_schema(self, entity_name: str) -> dict[str, str]:
+        """Load {col: type} from EntityRegistry.  Returns {} if unavailable."""
+        try:
+            from niamoto.common.database import Database
+            from niamoto.core.imports.registry import EntityRegistry
+
+            db_path = self._resolve_database_path()
+            if not db_path or not db_path.exists():
+                return {}
+            db = Database(str(db_path), read_only=True)
+            try:
+                registry = EntityRegistry(db)
+                meta = registry.get(entity_name)
+                fields = meta.config.get("schema", {}).get("fields", [])
+                return {
+                    f["name"]: f.get("type", "string")
+                    for f in fields
+                    if isinstance(f, dict) and "name" in f
+                }
+            finally:
+                try:
+                    db.close_db_session()
+                except Exception:  # noqa: BLE001
+                    pass
+                try:
+                    db.engine.dispose()
+                except Exception:  # noqa: BLE001
+                    pass
+        except Exception:  # noqa: BLE001
+            return {}
+
+    def _load_transform_source_schema(self, source_name: str) -> dict[str, str]:
+        """Load {col: type} from TransformSourceRegistry. Returns {} if unavailable."""
+        try:
+            from niamoto.common.database import Database
+            from niamoto.common.exceptions import DatabaseQueryError
+            from niamoto.core.imports.source_registry import TransformSourceRegistry
+
+            db_path = self._resolve_database_path()
+            if not db_path or not db_path.exists():
+                return {}
+            db = Database(str(db_path), read_only=True)
+            try:
+                if not db.has_table(TransformSourceRegistry.SOURCES_TABLE):
+                    return {}
+                registry = TransformSourceRegistry(db)
+                try:
+                    meta = registry.get(source_name)
+                except DatabaseQueryError:
+                    return {}
+                fields = meta.config.get("schema", {}).get("fields", [])
+                return {
+                    f["name"]: f.get("type", "string")
+                    for f in fields
+                    if isinstance(f, dict) and "name" in f
+                }
+            finally:
+                try:
+                    db.close_db_session()
+                except Exception:  # noqa: BLE001
+                    pass
+                try:
+                    db.engine.dispose()
+                except Exception:  # noqa: BLE001
+                    pass
+        except Exception:  # noqa: BLE001
+            return {}
+
+    def _resolve_database_path(self) -> Optional[Path]:
+        """Resolve the database path from config.yml."""
+        config_path = self.working_directory / "config" / "config.yml"
+        if not config_path.exists():
+            return None
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                cfg = yaml.safe_load(f) or {}
+            db_rel = cfg.get("database", {}).get("path")
+            if not db_rel:
+                return None
+            db_path = Path(db_rel)
+            if not db_path.is_absolute():
+                db_path = self.working_directory / db_path
+            return db_path
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _compare(
+        self,
+        entity_name: str,
+        file_path: str,
+        new_schema: dict[str, str],
+        old_schema: dict[str, str],
+        config_refs: ColumnRefMap,
+        *,
+        target_kind: TargetKind,
+        info_message: Optional[str] = None,
+    ) -> ImpactReport:
+        matched: list[ColumnMatch] = []
+        impacts: list[ImpactItem] = []
+
+        # All columns known from config + old schema
+        all_known = set(config_refs.keys()) | set(old_schema.keys())
+
+        for col in sorted(all_known):
+            in_new = col in new_schema
+            in_old = col in old_schema
+            refs = config_refs.get(col, [])
+
+            if not in_new and refs:
+                # Missing column referenced in config
+                highest_level = min(refs, key=lambda r: list(ImpactLevel).index(r[1]))[
+                    1
+                ]
+                impacts.append(
+                    ImpactItem(
+                        column=col,
+                        level=highest_level,
+                        detail=f"Column '{col}' missing in new file",
+                        referenced_in=[r[0] for r in refs],
+                    )
+                )
+            elif in_new and in_old:
+                old_t = old_schema[col]
+                new_t = new_schema[col]
+                matched.append(ColumnMatch(name=col, old_type=old_t, new_type=new_t))
+                if (
+                    old_t != new_t
+                    and refs
+                    and not self._is_non_informative_type_change(old_t, new_t)
+                ):
+                    impacts.append(
+                        ImpactItem(
+                            column=col,
+                            level=ImpactLevel.WARNING,
+                            detail=f"Type changed: {old_t} → {new_t}",
+                            referenced_in=[r[0] for r in refs],
+                            old_type=old_t,
+                            new_type=new_t,
+                        )
+                    )
+            elif in_new and not in_old and not refs:
+                # Column in new file only — not referenced anywhere
+                pass  # will be caught below as opportunity
+
+        # Detect new columns (opportunity)
+        if target_kind == TargetKind.IMPORT_ENTITY or old_schema:
+            for col in sorted(new_schema.keys()):
+                if col not in all_known:
+                    impacts.append(
+                        ImpactItem(
+                            column=col,
+                            level=ImpactLevel.OPPORTUNITY,
+                            detail=f"New column '{col}' not yet in config",
+                        )
+                    )
+
+        # Sort impacts by severity
+        level_order = list(ImpactLevel)
+        impacts.sort(key=lambda i: level_order.index(i.level))
+
+        return ImpactReport(
+            entity_name=entity_name,
+            file_path=file_path,
+            matched_columns=matched,
+            impacts=impacts,
+            info_message=info_message,
+        )
+
+    def _is_non_informative_type_change(self, old_type: str, new_type: str) -> bool:
+        return (
+            old_type in self._TYPELESS_SAMPLE_TYPES
+            or new_type in self._TYPELESS_SAMPLE_TYPES
+        )
+
+    def _resolve_target_kind(
+        self,
+        entity_name: str,
+        import_config: dict,
+        transform_config: list[dict],
+    ) -> TargetKind:
+        entities = import_config.get("entities", {})
+        for section in ("datasets", "references"):
+            if entity_name in entities.get(section, {}):
+                return TargetKind.IMPORT_ENTITY
+        if self._find_transform_source(entity_name, import_config, transform_config):
+            return TargetKind.TRANSFORM_SOURCE
+        return TargetKind.IMPORT_ENTITY
+
+    def _find_transform_source(
+        self,
+        entity_name: str,
+        import_config: dict,
+        transform_config: list[dict],
+    ) -> Optional[dict[str, str]]:
+        for source in self._list_transform_sources(import_config, transform_config):
+            if (
+                source["name"] == entity_name
+                or Path(source["path"]).stem == entity_name
+            ):
+                return source
+        return None
+
+    def _list_transform_sources(
+        self,
+        import_config: dict,
+        transform_config: list[dict],
+    ) -> list[dict[str, str]]:
+        entities = import_config.get("entities", {})
+        entity_names = set(entities.get("datasets", {})) | set(
+            entities.get("references", {})
+        )
+        sources: dict[str, dict[str, str]] = {}
+
+        for source in import_config.get("auxiliary_sources", []) or []:
+            name = source.get("name", "")
+            path = source.get("data", "")
+            grouping = source.get("grouping", "")
+            if name and path and name not in entity_names:
+                sources.setdefault(
+                    name,
+                    {"name": name, "path": path, "grouping": grouping},
+                )
+
+        for group in transform_config:
+            for source in group.get("sources", []):
+                path = source.get("data", "")
+                name = source.get("name", "")
+                grouping = source.get("grouping", "")
+                if not name or not path or "/" not in path or name in entity_names:
+                    continue
+                sources.setdefault(
+                    name,
+                    {"name": name, "path": path, "grouping": grouping},
+                )
+
+        return list(sources.values())

--- a/src/niamoto/core/services/transformer.py
+++ b/src/niamoto/core/services/transformer.py
@@ -3,6 +3,7 @@
 from typing import Dict, Any, List, Optional, Callable
 import logging
 import json
+from pathlib import Path
 import numpy as np
 import pandas as pd
 from datetime import datetime
@@ -77,8 +78,6 @@ class TransformerService:
         self.plugin_loader = PluginLoader()
 
         # Get project path for cascade resolution
-        from pathlib import Path
-
         project_path = Path(Config.get_niamoto_home())
 
         # Load all plugins (system, user, project) using cascade resolution
@@ -94,8 +93,6 @@ class TransformerService:
         Properly initialises all fields and loads plugins via cascade,
         but reuses an existing Database connection and skips CLI setup.
         """
-        from pathlib import Path
-
         svc = cls.__new__(cls)
         svc.db = db
         svc.config = Config(config_dir, create_default=False)
@@ -340,6 +337,7 @@ class TransformerService:
 
         # Filter configurations
         configs = self._filter_configs(group_by)
+        transform_succeeded = False
         try:
             self.db.enable_connection_reuse()
             if self.use_cli_integration and ProgressManager:
@@ -354,6 +352,7 @@ class TransformerService:
                 results = self._process_configs_simple(
                     configs, csv_file, recreate_table, progress_callback
                 )
+            transform_succeeded = True
         except Exception as e:
             if self.transform_metrics:
                 self.transform_metrics.add_error(str(e))
@@ -363,6 +362,8 @@ class TransformerService:
                 for group_name in list(self._table_buffers.keys()):
                     recreate = self._table_flush_modes.get(group_name, True)
                     self._flush_group_table(group_name, recreate)
+                if transform_succeeded:
+                    self._persist_transform_source_schemas(configs)
                 if getattr(self.db, "is_duckdb", False):
                     logger.info("Running DuckDB checkpoint after transformations")
                     self.db.optimize_database()
@@ -1030,6 +1031,59 @@ class TransformerService:
             )
 
         return data_sources
+
+    def _persist_transform_source_schemas(self, configs: List[Dict[str, Any]]) -> None:
+        """Persist observed schemas for file-based transform sources."""
+
+        from niamoto.core.imports.source_registry import TransformSourceRegistry
+        from niamoto.core.services.compatibility import CSVSchemaReader
+
+        config_dir = getattr(self.config, "config_dir", None)
+        if not isinstance(config_dir, (str, Path)):
+            return
+
+        project_root = Path(config_dir).parent
+        registry = TransformSourceRegistry(self.db)
+        seen_sources: set[str] = set()
+
+        for group_config in configs:
+            for source in group_config.get("sources", []):
+                source_name = source.get("name", "")
+                source_path = source.get("data", "")
+                grouping = source.get("grouping", "")
+
+                if (
+                    not source_name
+                    or not source_path
+                    or "/" not in source_path
+                    or source_name in seen_sources
+                ):
+                    continue
+
+                resolved_path = (project_root / source_path).resolve()
+                if not resolved_path.exists():
+                    logger.debug(
+                        "Skipping transform source baseline for missing file: %s",
+                        resolved_path,
+                    )
+                    continue
+
+                fields, error = CSVSchemaReader.read_schema(resolved_path)
+                if error:
+                    logger.warning(
+                        "Failed to persist transform source baseline for %s: %s",
+                        source_name,
+                        error,
+                    )
+                    continue
+
+                registry.register_source(
+                    name=source_name,
+                    path=source_path,
+                    grouping=grouping,
+                    config={"schema": {"fields": fields}},
+                )
+                seen_sources.add(source_name)
 
     def _create_group_table(
         self, group_by: str, widgets_config: Dict[str, Any], recreate_table: bool = True

--- a/src/niamoto/gui/api/routers/imports.py
+++ b/src/niamoto/gui/api/routers/imports.py
@@ -957,3 +957,92 @@ async def process_generic_import_entity(
             entity_name,
             e,
         )
+
+
+# ---------------------------------------------------------------------------
+# Pre-Import Impact Check
+# ---------------------------------------------------------------------------
+
+
+class ImpactCheckRequest(BaseModel):
+    file_path: str  # relative to project root
+
+
+class ImpactItemResponse(BaseModel):
+    column: str
+    level: str
+    detail: str
+    referenced_in: List[str] = []
+    old_type: Optional[str] = None
+    new_type: Optional[str] = None
+
+
+class ColumnMatchResponse(BaseModel):
+    name: str
+    old_type: str
+    new_type: str
+
+
+class ImpactCheckResponse(BaseModel):
+    entity_name: Optional[str] = None
+    matched_columns: List[ColumnMatchResponse] = []
+    impacts: List[ImpactItemResponse] = []
+    error: Optional[str] = None
+    skipped_reason: Optional[str] = None
+    info_message: Optional[str] = None
+    has_blockers: bool = False
+    has_warnings: bool = False
+    has_opportunities: bool = False
+
+
+@router.post("/impact-check", response_model=ImpactCheckResponse)
+async def impact_check(request: ImpactCheckRequest):
+    """Check compatibility between a source file and existing configuration.
+
+    Resolves the entity from the file path basename, then runs the impact
+    check against import.yml + transform.yml.
+    """
+    from pathlib import Path
+
+    from ..context import get_working_directory
+    from niamoto.core.services.compatibility import CompatibilityService
+
+    work_dir = get_working_directory()
+
+    # Path validation FIRST
+    resolved = (work_dir / request.file_path).resolve()
+    if not resolved.is_relative_to(work_dir.resolve()):
+        raise HTTPException(status_code=400, detail="Path outside project directory")
+
+    service = CompatibilityService(work_dir)
+    filename = Path(request.file_path).name
+    entity_name = service.resolve_entity(filename)
+
+    if entity_name is None:
+        return ImpactCheckResponse()
+
+    report = service.check_compatibility(entity_name, request.file_path)
+    return ImpactCheckResponse(
+        entity_name=report.entity_name,
+        matched_columns=[
+            ColumnMatchResponse(name=m.name, old_type=m.old_type, new_type=m.new_type)
+            for m in report.matched_columns
+        ],
+        impacts=[
+            ImpactItemResponse(
+                column=i.column,
+                level=i.level.value,
+                detail=i.detail,
+                referenced_in=i.referenced_in,
+                old_type=i.old_type,
+                new_type=i.new_type,
+            )
+            for i in report.impacts
+        ],
+        error=report.error,
+        skipped_reason=report.skipped_reason,
+        info_message=getattr(report, "info_message", None),
+        has_blockers=report.has_blockers,
+        has_warnings=report.has_warnings,
+        has_opportunities=report.has_opportunities,
+    )

--- a/src/niamoto/gui/ui/src/features/import/api/compatibility.ts
+++ b/src/niamoto/gui/ui/src/features/import/api/compatibility.ts
@@ -1,0 +1,43 @@
+/**
+ * API client for pre-import impact check
+ */
+
+import { apiClient } from '@/shared/lib/api/client'
+
+export interface ImpactItem {
+  column: string
+  level: 'blocks_import' | 'breaks_transform' | 'warning' | 'opportunity'
+  detail: string
+  referenced_in: string[]
+  old_type?: string
+  new_type?: string
+}
+
+export interface ColumnMatch {
+  name: string
+  old_type: string
+  new_type: string
+}
+
+export interface ImpactCheckResult {
+  entity_name: string | null
+  matched_columns: ColumnMatch[]
+  impacts: ImpactItem[]
+  error?: string
+  skipped_reason?: string
+  info_message?: string
+  has_blockers: boolean
+  has_warnings: boolean
+  has_opportunities: boolean
+}
+
+/**
+ * Run a pre-import impact check for a single file.
+ * The backend resolves the entity from the filename and runs the check.
+ */
+export async function impactCheck(filePath: string): Promise<ImpactCheckResult> {
+  const { data } = await apiClient.post<ImpactCheckResult>('/imports/impact-check', {
+    file_path: filePath,
+  })
+  return data
+}

--- a/src/niamoto/gui/ui/src/features/import/components/CompatibilityPanel.tsx
+++ b/src/niamoto/gui/ui/src/features/import/components/CompatibilityPanel.tsx
@@ -1,0 +1,156 @@
+/**
+ * CompatibilityPanel - Shows pre-import impact check results
+ *
+ * Displays impact items grouped by severity:
+ * - Red: blocks_import (missing columns in import.yml)
+ * - Orange: breaks_transform (missing columns in transform.yml)
+ * - Yellow: warning (type changes)
+ * - Blue: opportunity (new columns)
+ */
+
+import { AlertTriangle, AlertCircle, Info, Sparkles, CheckCircle2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { ImpactCheckResult, ImpactItem } from '../api/compatibility'
+
+interface CompatibilityPanelProps {
+  reports: ImpactCheckResult[]
+  unmatchedFiles: string[]
+  onContinue: () => void
+  onFixData: () => void
+}
+
+const LEVEL_CONFIG = {
+  blocks_import: {
+    icon: AlertCircle,
+    label: 'Blocks Import',
+    className: 'text-red-600 dark:text-red-400',
+    bgClassName: 'bg-red-50 dark:bg-red-950/30',
+    borderClassName: 'border-red-200 dark:border-red-900',
+  },
+  breaks_transform: {
+    icon: AlertTriangle,
+    label: 'Breaks Transform',
+    className: 'text-orange-600 dark:text-orange-400',
+    bgClassName: 'bg-orange-50 dark:bg-orange-950/30',
+    borderClassName: 'border-orange-200 dark:border-orange-900',
+  },
+  warning: {
+    icon: Info,
+    label: 'Warning',
+    className: 'text-yellow-600 dark:text-yellow-400',
+    bgClassName: 'bg-yellow-50 dark:bg-yellow-950/30',
+    borderClassName: 'border-yellow-200 dark:border-yellow-900',
+  },
+  opportunity: {
+    icon: Sparkles,
+    label: 'New Column',
+    className: 'text-blue-600 dark:text-blue-400',
+    bgClassName: 'bg-blue-50 dark:bg-blue-950/30',
+    borderClassName: 'border-blue-200 dark:border-blue-900',
+  },
+} as const
+
+function ImpactItemRow({ item }: { item: ImpactItem }) {
+  const config = LEVEL_CONFIG[item.level]
+  const Icon = config.icon
+
+  return (
+    <div className={`flex items-start gap-2 rounded-md border px-3 py-2 ${config.bgClassName} ${config.borderClassName}`}>
+      <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${config.className}`} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className={`text-xs font-medium uppercase ${config.className}`}>{config.label}</span>
+          <code className="text-sm font-semibold">{item.column}</code>
+        </div>
+        <p className="text-sm text-muted-foreground">{item.detail}</p>
+        {item.referenced_in.length > 0 && (
+          <div className="mt-1 space-y-0.5">
+            {item.referenced_in.map((ref, i) => (
+              <p key={i} className="text-xs text-muted-foreground/70">&rarr; {ref}</p>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function CompatibilityPanel({ reports, unmatchedFiles, onContinue, onFixData }: CompatibilityPanelProps) {
+  const totalMatched = reports.reduce((sum, r) => sum + r.matched_columns.length, 0)
+  const hasBlockers = reports.some((r) => r.has_blockers)
+  const hasWarnings = reports.some((r) => r.has_warnings)
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <AlertTriangle className="h-5 w-5 text-yellow-500" />
+          Compatibility Check
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Matched columns summary */}
+        {totalMatched > 0 && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+            <span>{totalMatched} columns OK</span>
+          </div>
+        )}
+
+        {/* Impact items per report */}
+        {reports.map((report) => (
+          <div key={report.entity_name} className="space-y-2">
+            {reports.length > 1 && (
+              <h4 className="text-sm font-medium">{report.entity_name}</h4>
+            )}
+            {report.skipped_reason && (
+              <div className="flex items-start gap-2 rounded-md border border-muted bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                <Info className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{report.skipped_reason}</span>
+              </div>
+            )}
+            {report.info_message && (
+              <div className="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700 dark:border-blue-900 dark:bg-blue-950/30 dark:text-blue-300">
+                <Info className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{report.info_message}</span>
+              </div>
+            )}
+            {report.error && (
+              <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600 dark:border-red-900 dark:bg-red-950/30 dark:text-red-400">
+                {report.error}
+              </div>
+            )}
+            {report.impacts.map((item, i) => (
+              <ImpactItemRow key={`${report.entity_name}-${i}`} item={item} />
+            ))}
+          </div>
+        ))}
+
+        {/* Unmatched files info */}
+        {unmatchedFiles.length > 0 && (
+          <div className="flex items-start gap-2 text-sm text-muted-foreground">
+            <Info className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>
+              {unmatchedFiles.length} new file{unmatchedFiles.length > 1 ? 's' : ''} — will be auto-configured
+            </span>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center gap-3 pt-2">
+          <Button
+            onClick={onContinue}
+            variant={hasBlockers ? 'outline' : 'default'}
+            size="sm"
+          >
+            {hasBlockers || hasWarnings ? 'Continue anyway' : 'Continue'}
+          </Button>
+          <Button onClick={onFixData} variant="ghost" size="sm">
+            Fix data
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/niamoto/gui/ui/src/features/import/hooks/useCompatibilityCheck.ts
+++ b/src/niamoto/gui/ui/src/features/import/hooks/useCompatibilityCheck.ts
@@ -1,0 +1,86 @@
+/**
+ * Hook to run pre-import impact checks after file upload.
+ *
+ * For each uploaded file, calls POST /api/imports/impact-check.
+ * Returns matched reports (entity found) and unmatched file names.
+ */
+
+import { useState, useCallback } from 'react'
+import { impactCheck, type ImpactCheckResult } from '../api/compatibility'
+
+interface CompatibilityCheckState {
+  isChecking: boolean
+  matched: ImpactCheckResult[]
+  unmatched: string[]
+  error: string | null
+}
+
+export function useCompatibilityCheck() {
+  const [state, setState] = useState<CompatibilityCheckState>({
+    isChecking: false,
+    matched: [],
+    unmatched: [],
+    error: null,
+  })
+
+  const check = useCallback(async (files: Array<{ name: string; path: string }>) => {
+    setState({ isChecking: true, matched: [], unmatched: [], error: null })
+
+    try {
+      const results = await Promise.all(
+        files.map(async (f) => {
+          try {
+            const result = await impactCheck(f.path)
+            return { file: f, result }
+          } catch {
+            // Non-blocking: if the API fails, treat as unmatched
+            return { file: f, result: null }
+          }
+        })
+      )
+
+      const matched: ImpactCheckResult[] = []
+      const unmatched: string[] = []
+
+      for (const { file, result } of results) {
+        if (result && result.entity_name) {
+          matched.push(result)
+        } else {
+          unmatched.push(file.name)
+        }
+      }
+
+      const hasImpacts = matched.some(
+        (r) => r.impacts.length > 0 || r.error || r.skipped_reason || r.info_message
+      )
+
+      setState({
+        isChecking: false,
+        matched: hasImpacts ? matched : [],
+        unmatched,
+        error: null,
+      })
+
+      return { matched: hasImpacts ? matched : [], unmatched }
+    } catch (err: any) {
+      // Non-blocking: if everything fails, skip the check
+      setState({
+        isChecking: false,
+        matched: [],
+        unmatched: files.map((f) => f.name),
+        error: null,
+      })
+      return { matched: [], unmatched: files.map((f) => f.name) }
+    }
+  }, [])
+
+  const reset = useCallback(() => {
+    setState({ isChecking: false, matched: [], unmatched: [], error: null })
+  }, [])
+
+  return {
+    ...state,
+    check,
+    reset,
+  }
+}

--- a/tests/core/services/test_compatibility.py
+++ b/tests/core/services/test_compatibility.py
@@ -1,0 +1,1385 @@
+"""Unit tests for the pre-import impact check service."""
+
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+import yaml
+
+from niamoto.common.database import Database
+from niamoto.core.imports.registry import EntityKind, EntityRegistry
+from niamoto.core.imports.source_registry import TransformSourceRegistry
+from niamoto.core.services.compatibility import (
+    CSVSchemaReader,
+    CompatibilityService,
+    ConfigRefCollector,
+    EntityResolver,
+    ImpactLevel,
+    TargetKind,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_IMPORT_CONFIG = {
+    "entities": {
+        "datasets": {
+            "occurrences": {
+                "connector": {"type": "file", "path": "imports/occurrences.csv"},
+                "schema": {
+                    "id_field": "id",
+                    "fields": [
+                        {"name": "id", "type": "integer"},
+                        {"name": "species", "type": "string"},
+                        {"name": "dbh", "type": "float"},
+                    ],
+                },
+                "links": [
+                    {
+                        "entity": "taxons",
+                        "field": "id_taxonref",
+                        "target_field": "taxons_id",
+                    }
+                ],
+            },
+        },
+        "references": {
+            "taxons": {
+                "kind": "hierarchical",
+                "connector": {
+                    "type": "derived",
+                    "source": "occurrences",
+                    "extraction": {
+                        "levels": [
+                            {"name": "family", "column": "family"},
+                            {"name": "genus", "column": "genus"},
+                            {"name": "species", "column": "species"},
+                        ],
+                        "id_column": "id_taxonref",
+                        "name_column": "taxaname",
+                        "additional_columns": ["infra"],
+                    },
+                },
+                "hierarchy": {
+                    "strategy": "adjacency_list",
+                    "levels": ["family", "genus", "species"],
+                },
+                "schema": {"id_field": "id", "fields": []},
+            },
+            "plots": {
+                "connector": {
+                    "type": "file",
+                    "path": "imports/plots.csv",
+                },
+                "schema": {
+                    "id_field": "id_plot",
+                    "fields": [{"name": "geo_pt", "type": "geometry"}],
+                },
+            },
+        },
+    }
+}
+
+SAMPLE_TRANSFORM_CONFIG = [
+    {
+        "group_by": "taxons",
+        "sources": [
+            {
+                "name": "occurrences",
+                "data": "occurrences",
+                "grouping": "taxons",
+                "relation": {
+                    "plugin": "nested_set",
+                    "key": "id_taxonref",
+                    "ref_key": "taxons_id",
+                    "fields": {
+                        "parent": "parent_id",
+                        "left": "lft",
+                        "right": "rght",
+                    },
+                },
+            }
+        ],
+    },
+    {
+        "group_by": "plots",
+        "sources": [
+            {
+                "name": "occurrences",
+                "data": "occurrences",
+                "grouping": "plots",
+                "relation": {
+                    "plugin": "direct_reference",
+                    "key": "plot_name",
+                    "ref_key": "plot",
+                },
+            },
+            {
+                "name": "plot_stats",
+                "data": "imports/raw_plot_stats.csv",
+                "grouping": "plots",
+                "relation": {
+                    "plugin": "stats_loader",
+                    "key": "id",
+                    "ref_field": "id_plot",
+                    "match_field": "plot_id",
+                },
+            },
+        ],
+        "widgets_data": {
+            "plot_area": {
+                "plugin": "direct_attribute",
+                "params": {"source": "plot_stats", "field": "area_ha"},
+            },
+            "plot_metrics": {
+                "plugin": "field_aggregator",
+                "params": {
+                    "fields": [
+                        {"source": "plot_stats", "field": "rainfall", "target": "x"},
+                        {"source": "plots", "field": "plot", "target": "plot"},
+                    ]
+                },
+            },
+        },
+    },
+]
+
+
+# ===================================================================
+# TestConfigRefCollector
+# ===================================================================
+
+
+class TestConfigRefCollector:
+    def setup_method(self):
+        self.collector = ConfigRefCollector()
+
+    def test_collects_dataset_schema_refs(self):
+        refs = self.collector.collect("occurrences", SAMPLE_IMPORT_CONFIG, [])
+        # id_field + 3 fields + 2 link columns
+        assert "id" in refs
+        assert "species" in refs
+        assert "dbh" in refs
+        assert "id_taxonref" in refs  # link field
+        assert "taxons_id" in refs  # link target_field
+        for col in ("id", "species", "dbh", "id_taxonref", "taxons_id"):
+            assert all(lvl == ImpactLevel.BLOCKS_IMPORT for _, lvl in refs[col])
+
+    def test_collects_reference_hierarchy_refs(self):
+        refs = self.collector.collect("taxons", SAMPLE_IMPORT_CONFIG, [])
+        # hierarchy levels are strings, mapped as column names
+        assert "family" in refs
+        assert "genus" in refs
+        assert "species" in refs
+
+    def test_collects_extraction_refs_for_reference(self):
+        """Extraction columns are collected for the *reference* entity in import.yml."""
+        refs = self.collector.collect("taxons", SAMPLE_IMPORT_CONFIG, [])
+        assert "id_taxonref" in refs  # extraction.id_column
+        assert "taxaname" in refs  # extraction.name_column
+        assert "infra" in refs  # extraction.additional_columns
+
+    def test_collects_derived_extraction_refs_for_source_dataset(self):
+        """When checking a dataset, extraction columns from DERIVED references
+        that depend on it must also be collected (P1 fix)."""
+        refs = self.collector.collect("occurrences", SAMPLE_IMPORT_CONFIG, [])
+        # taxons is DERIVED from occurrences → extraction levels reference
+        # columns that exist in the occurrences CSV
+        assert "family" in refs
+        assert "genus" in refs
+        assert "species" in refs
+        assert "infra" in refs  # additional_columns
+        assert "id_taxonref" in refs  # extraction.id_column
+        assert "taxaname" in refs  # extraction.name_column
+        for col in ("family", "genus", "species", "infra", "id_taxonref", "taxaname"):
+            assert any(lvl == ImpactLevel.BLOCKS_IMPORT for _, lvl in refs[col])
+
+    def test_collects_transform_relation_key_for_data_entity(self):
+        refs = self.collector.collect(
+            "occurrences", SAMPLE_IMPORT_CONFIG, SAMPLE_TRANSFORM_CONFIG
+        )
+        # relation.key in taxons group → id_taxonref → belongs to occurrences
+        assert "id_taxonref" in refs
+        transform_refs = [
+            (p, lvl) for p, lvl in refs["id_taxonref"] if "transform" in p
+        ]
+        assert any(lvl == ImpactLevel.BREAKS_TRANSFORM for _, lvl in transform_refs)
+
+        # relation.key in plots group → plot_name → belongs to occurrences
+        assert "plot_name" in refs
+        assert any(lvl == ImpactLevel.BREAKS_TRANSFORM for _, lvl in refs["plot_name"])
+
+    def test_collects_transform_ref_key_for_grouping_entity(self):
+        refs = self.collector.collect(
+            "taxons", SAMPLE_IMPORT_CONFIG, SAMPLE_TRANSFORM_CONFIG
+        )
+        # relation.ref_key = taxons_id → belongs to taxons (grouping)
+        assert "taxons_id" in refs
+        transform_refs = [(p, lvl) for p, lvl in refs["taxons_id"] if "transform" in p]
+        assert any(lvl == ImpactLevel.BREAKS_TRANSFORM for _, lvl in transform_refs)
+
+    def test_collects_relation_fields_values_for_grouping_entity(self):
+        refs = self.collector.collect(
+            "taxons", SAMPLE_IMPORT_CONFIG, SAMPLE_TRANSFORM_CONFIG
+        )
+        # relation.fields values: parent_id, lft, rght → belong to taxons
+        assert "parent_id" in refs
+        assert "lft" in refs
+        assert "rght" in refs
+        for col in ("parent_id", "lft", "rght"):
+            assert any(lvl == ImpactLevel.BREAKS_TRANSFORM for _, lvl in refs[col])
+
+    def test_attributes_key_to_data_not_grouping(self):
+        refs = self.collector.collect(
+            "taxons", SAMPLE_IMPORT_CONFIG, SAMPLE_TRANSFORM_CONFIG
+        )
+        # relation.key = id_taxonref is for occurrences (data), NOT taxons
+        # BUT id_taxonref is also in extraction.id_column for taxons
+        # so we check that transform refs for id_taxonref are NOT present for taxons
+        transform_id_refs = [
+            (p, lvl)
+            for p, lvl in refs.get("id_taxonref", [])
+            if "transform" in p and "relation.key" in p
+        ]
+        assert len(transform_id_refs) == 0
+
+    def test_attributes_ref_key_to_grouping_not_data(self):
+        refs = self.collector.collect(
+            "occurrences", SAMPLE_IMPORT_CONFIG, SAMPLE_TRANSFORM_CONFIG
+        )
+        # relation.ref_key = taxons_id belongs to taxons, NOT occurrences
+        # So occurrences should NOT have transform refs for taxons_id
+        if "taxons_id" in refs:
+            transform_refs = [
+                (p, lvl) for p, lvl in refs["taxons_id"] if "transform" in p
+            ]
+            assert len(transform_refs) == 0
+
+    def test_collects_ref_field_for_grouping_entity(self):
+        refs = self.collector.collect(
+            "plots", SAMPLE_IMPORT_CONFIG, SAMPLE_TRANSFORM_CONFIG
+        )
+        # ref_field = id_plot from plot_stats source → belongs to plots
+        assert "id_plot" in refs
+        transform_refs = [(p, lvl) for p, lvl in refs["id_plot"] if "transform" in p]
+        assert any(lvl == ImpactLevel.BREAKS_TRANSFORM for _, lvl in transform_refs)
+
+    def test_collects_match_field_for_transform_source(self):
+        refs = self.collector.collect(
+            "plot_stats", SAMPLE_IMPORT_CONFIG, SAMPLE_TRANSFORM_CONFIG
+        )
+        assert "id" in refs
+        assert "plot_id" in refs
+        transform_refs = [(p, lvl) for p, lvl in refs["plot_id"] if "transform" in p]
+        assert any("relation.match_field" in path for path, _ in transform_refs)
+
+    def test_collects_direct_attribute_refs_for_transform_source(self):
+        refs = self.collector.collect(
+            "plot_stats", SAMPLE_IMPORT_CONFIG, SAMPLE_TRANSFORM_CONFIG
+        )
+        assert "area_ha" in refs
+        assert any("params.field" in path for path, _ in refs["area_ha"])
+
+    def test_collects_field_aggregator_refs_for_transform_source(self):
+        refs = self.collector.collect(
+            "plot_stats", SAMPLE_IMPORT_CONFIG, SAMPLE_TRANSFORM_CONFIG
+        )
+        assert "rainfall" in refs
+        assert any("params.fields[0].field" in path for path, _ in refs["rainfall"])
+
+    def test_collects_class_object_series_refs_for_transform_source(self):
+        transform_cfg = [
+            {
+                "group_by": "plots",
+                "sources": [
+                    {
+                        "name": "plot_stats",
+                        "data": "imports/raw_plot_stats.csv",
+                        "grouping": "plots",
+                        "relation": {"plugin": "stats_loader", "key": "id"},
+                    }
+                ],
+                "widgets_data": {
+                    "fragmentation_distribution": {
+                        "plugin": "class_object_series_extractor",
+                        "params": {
+                            "source": "plot_stats",
+                            "class_object": "forest_fragmentation",
+                            "size_field": {"input": "class_name", "output": "sizes"},
+                            "value_field": {
+                                "input": "class_value",
+                                "output": "values",
+                            },
+                        },
+                    }
+                },
+            }
+        ]
+
+        refs = self.collector.collect("plot_stats", SAMPLE_IMPORT_CONFIG, transform_cfg)
+
+        assert "class_object" in refs
+        assert "class_name" in refs
+        assert "class_value" in refs
+        assert any("params.size_field.input" in path for path, _ in refs["class_name"])
+        assert any(
+            "params.value_field.input" in path for path, _ in refs["class_value"]
+        )
+
+    def test_collects_class_object_field_aggregator_refs_for_transform_source(self):
+        transform_cfg = [
+            {
+                "group_by": "shapes",
+                "sources": [
+                    {
+                        "name": "shape_stats",
+                        "data": "imports/raw_shape_stats.csv",
+                        "grouping": "shapes",
+                        "relation": {"plugin": "stats_loader", "key": "id"},
+                    }
+                ],
+                "widgets_data": {
+                    "general_info": {
+                        "plugin": "class_object_field_aggregator",
+                        "params": {
+                            "source": "shape_stats",
+                            "fields": [
+                                {"class_object": "land_area_ha", "target": "area"},
+                            ],
+                        },
+                    }
+                },
+            }
+        ]
+
+        refs = self.collector.collect(
+            "shape_stats", SAMPLE_IMPORT_CONFIG, transform_cfg
+        )
+
+        assert "class_object" in refs
+        assert "class_value" in refs
+        assert "class_name" not in refs
+
+    def test_collects_class_object_axis_refs_for_transform_source(self):
+        transform_cfg = [
+            {
+                "group_by": "shapes",
+                "sources": [
+                    {
+                        "name": "shape_stats",
+                        "data": "imports/raw_shape_stats.csv",
+                        "grouping": "shapes",
+                        "relation": {"plugin": "stats_loader", "key": "id"},
+                    }
+                ],
+                "widgets_data": {
+                    "forest_types_by_elevation": {
+                        "plugin": "class_object_series_by_axis_extractor",
+                        "params": {
+                            "source": "shape_stats",
+                            "axis": {"field": "class_name", "output_field": "bins"},
+                            "types": {"forest": "forest_mature_elevation"},
+                        },
+                    }
+                },
+            }
+        ]
+
+        refs = self.collector.collect(
+            "shape_stats", SAMPLE_IMPORT_CONFIG, transform_cfg
+        )
+
+        assert "class_object" in refs
+        assert "class_name" in refs
+        assert "class_value" in refs
+        assert any("params.axis.field" in path for path, _ in refs["class_name"])
+
+    def test_handles_missing_import_config(self):
+        refs = self.collector.collect("occurrences", {}, [])
+        assert refs == {}
+
+    def test_handles_missing_transform_config(self):
+        refs = self.collector.collect("occurrences", SAMPLE_IMPORT_CONFIG, [])
+        # Should still have import refs, no crash
+        assert "id" in refs
+
+    def test_collects_simple_widget_refs_for_source_entity(self):
+        transform_with_params = [
+            {
+                "group_by": "taxons",
+                "sources": [
+                    {
+                        "name": "occ",
+                        "data": "occurrences",
+                        "grouping": "taxons",
+                        "relation": {"plugin": "nested_set", "key": "id_taxonref"},
+                    }
+                ],
+                "widgets_data": {
+                    "dbh_hist": {
+                        "plugin": "binned_distribution",
+                        "params": {"source": "occurrences", "field": "dbh"},
+                    },
+                    "geo": {
+                        "plugin": "geospatial_extractor",
+                        "params": {"source": "occurrences", "field": "geo_pt"},
+                    },
+                },
+            }
+        ]
+        refs = self.collector.collect(
+            "occurrences", SAMPLE_IMPORT_CONFIG, transform_with_params
+        )
+        assert "dbh" in refs
+        assert any("params.field" in path for path, _ in refs["dbh"])
+        assert "geo_pt" in refs
+        assert any("params.field" in path for path, _ in refs["geo_pt"])
+
+    def test_collects_time_series_refs_for_source_entity(self):
+        transform_cfg = [
+            {
+                "group_by": "taxons",
+                "sources": [
+                    {
+                        "name": "occurrences",
+                        "data": "occurrences",
+                        "grouping": "taxons",
+                        "relation": {"plugin": "nested_set", "key": "id_taxonref"},
+                    }
+                ],
+                "widgets_data": {
+                    "phenology": {
+                        "plugin": "time_series_analysis",
+                        "params": {
+                            "source": "occurrences",
+                            "fields": {"flower": "flower", "fruit": "fruit"},
+                            "time_field": "month_obs",
+                        },
+                    }
+                },
+            }
+        ]
+
+        refs = self.collector.collect(
+            "occurrences", SAMPLE_IMPORT_CONFIG, transform_cfg
+        )
+
+        assert "month_obs" in refs
+        assert "flower" in refs
+        assert "fruit" in refs
+        assert any("params.time_field" in path for path, _ in refs["month_obs"])
+        assert any("params.fields.flower" in path for path, _ in refs["flower"])
+        assert any("params.fields.fruit" in path for path, _ in refs["fruit"])
+
+    def test_collects_widget_refs_for_grouping_entity_without_source_entry(self):
+        transform_cfg = [
+            {
+                "group_by": "plots",
+                "sources": [
+                    {
+                        "name": "occurrences",
+                        "data": "occurrences",
+                        "grouping": "plots",
+                        "relation": {
+                            "plugin": "direct_reference",
+                            "key": "plot_name",
+                            "ref_key": "plot",
+                        },
+                    }
+                ],
+                "widgets_data": {
+                    "summary": {
+                        "plugin": "statistical_summary",
+                        "params": {"source": "plots", "field": "biomass"},
+                    },
+                    "nav": {
+                        "plugin": "hierarchical_nav_widget",
+                        "params": {
+                            "referential_data": "plots",
+                            "id_field": "id_plot",
+                            "name_field": "plot_label",
+                            "parent_id_field": "parent_id",
+                        },
+                    },
+                },
+            }
+        ]
+
+        refs = self.collector.collect("plots", SAMPLE_IMPORT_CONFIG, transform_cfg)
+
+        assert "biomass" in refs
+        assert any("params.field" in path for path, _ in refs["biomass"])
+        assert "id_plot" in refs
+        assert "plot_label" in refs
+        assert "parent_id" in refs
+        assert any("params.id_field" in path for path, _ in refs["id_plot"])
+
+    def test_collects_top_ranking_hierarchy_and_join_refs(self):
+        transform_cfg = [
+            {
+                "group_by": "taxons",
+                "sources": [
+                    {
+                        "name": "occurrences",
+                        "data": "occurrences",
+                        "grouping": "taxons",
+                        "relation": {"plugin": "nested_set", "key": "id_taxonref"},
+                    }
+                ],
+                "widgets_data": {
+                    "top_taxa": {
+                        "plugin": "top_ranking",
+                        "params": {
+                            "source": "occurrences",
+                            "field": "id_taxonref",
+                            "mode": "hierarchical",
+                            "hierarchy_table": "taxons",
+                            "hierarchy_columns": {
+                                "id": "taxons_id",
+                                "name": "full_name",
+                                "rank": "rank_name",
+                                "parent_id": "parent_id",
+                                "left": "lft",
+                                "right": "rght",
+                            },
+                        },
+                    },
+                    "joined_taxa": {
+                        "plugin": "top_ranking",
+                        "params": {
+                            "source": "occurrences",
+                            "field": "occurrence_id",
+                            "mode": "join",
+                            "join_table": "taxons",
+                            "join_columns": {
+                                "source_id": "occurrence_id",
+                                "hierarchy_id": "taxons_id",
+                            },
+                        },
+                    },
+                },
+            }
+        ]
+
+        occ_refs = self.collector.collect(
+            "occurrences", SAMPLE_IMPORT_CONFIG, transform_cfg
+        )
+        assert "id_taxonref" in occ_refs
+        assert "occurrence_id" in occ_refs
+        assert any("params.field" in path for path, _ in occ_refs["id_taxonref"])
+
+        taxon_refs = self.collector.collect(
+            "taxons", SAMPLE_IMPORT_CONFIG, transform_cfg
+        )
+        for column in (
+            "taxons_id",
+            "full_name",
+            "rank_name",
+            "parent_id",
+            "lft",
+            "rght",
+        ):
+            assert column in taxon_refs
+        assert any(
+            "params.hierarchy_columns.id" in path for path, _ in taxon_refs["taxons_id"]
+        )
+
+    def test_collects_geospatial_secondary_fields(self):
+        transform_cfg = [
+            {
+                "group_by": "taxons",
+                "sources": [
+                    {
+                        "name": "occurrences",
+                        "data": "occurrences",
+                        "grouping": "taxons",
+                        "relation": {"plugin": "nested_set", "key": "id_taxonref"},
+                    }
+                ],
+                "widgets_data": {
+                    "map": {
+                        "plugin": "geospatial_extractor",
+                        "params": {
+                            "source": "occurrences",
+                            "field": "geo_pt",
+                            "properties": ["species", "dbh"],
+                            "children_properties": ["family"],
+                            "hierarchy_config": {
+                                "type_field": "plot_type",
+                                "parent_field": "parent_id",
+                                "left_field": "lft",
+                                "right_field": "rght",
+                            },
+                        },
+                    }
+                },
+            }
+        ]
+
+        refs = self.collector.collect(
+            "occurrences", SAMPLE_IMPORT_CONFIG, transform_cfg
+        )
+
+        for column in (
+            "geo_pt",
+            "species",
+            "dbh",
+            "family",
+            "plot_type",
+            "parent_id",
+            "lft",
+            "rght",
+        ):
+            assert column in refs
+        assert any("params.properties[0]" in path for path, _ in refs["species"])
+        assert any(
+            "params.hierarchy_config.type_field" in path
+            for path, _ in refs["plot_type"]
+        )
+
+    def test_collects_entity_map_refs_for_grouping_entity(self):
+        transform_cfg = [
+            {
+                "group_by": "plots",
+                "sources": [],
+                "widgets_data": {
+                    "map": {
+                        "plugin": "entity_map_extractor",
+                        "params": {
+                            "entity_table": "entity_plots",
+                            "geometry_field": "geo_pt",
+                            "name_field": "id_plot",
+                            "id_field": "id_plot",
+                        },
+                    }
+                },
+            }
+        ]
+
+        refs = self.collector.collect("plots", SAMPLE_IMPORT_CONFIG, transform_cfg)
+
+        assert "geo_pt" in refs
+        assert "id_plot" in refs
+        assert any("params.geometry_field" in path for path, _ in refs["geo_pt"])
+
+
+# ===================================================================
+# TestCSVSchemaReader
+# ===================================================================
+
+
+class TestCSVSchemaReader:
+    def test_reads_simple_csv(self, tmp_path):
+        csv = tmp_path / "test.csv"
+        csv.write_text("id,name,value\n1,a,1.5\n2,b,2.5\n")
+        fields, err = CSVSchemaReader.read_schema(csv)
+        assert err is None
+        assert len(fields) == 3
+        names = {f["name"] for f in fields}
+        assert names == {"id", "name", "value"}
+        types = {f["name"]: f["type"] for f in fields}
+        assert types["id"] == "integer"
+        assert types["name"] == "string"
+        assert types["value"] == "float"
+
+    def test_handles_semicolon_separator(self, tmp_path):
+        csv = tmp_path / "euro.csv"
+        csv.write_text("id;nom;val\n1;test;3.14\n")
+        fields, err = CSVSchemaReader.read_schema(csv)
+        assert err is None
+        assert {f["name"] for f in fields} == {"id", "nom", "val"}
+
+    def test_handles_latin1_encoding(self, tmp_path):
+        csv = tmp_path / "latin.csv"
+        csv.write_bytes(b"id;nom\n1;\xe9l\xe8ve\n")
+        fields, err = CSVSchemaReader.read_schema(csv)
+        assert err is None
+        assert len(fields) == 2
+
+    def test_all_null_sample_column_is_unknown(self, tmp_path):
+        csv = tmp_path / "nulls.csv"
+        csv.write_text("id,optional\n1,\n2,\n3,\n")
+        fields, err = CSVSchemaReader.read_schema(csv)
+        assert err is None
+        types = {f["name"]: f["type"] for f in fields}
+        assert types["optional"] == "unknown"
+
+    def test_returns_error_for_empty_file(self, tmp_path):
+        csv = tmp_path / "empty.csv"
+        csv.write_text("")
+        fields, err = CSVSchemaReader.read_schema(csv)
+        assert err is not None
+
+    def test_returns_error_for_nonexistent_file(self, tmp_path):
+        csv = tmp_path / "nonexistent.csv"
+        fields, err = CSVSchemaReader.read_schema(csv)
+        assert err is not None
+
+    def test_header_only_returns_string_types(self, tmp_path):
+        csv = tmp_path / "header_only.csv"
+        csv.write_text("id,name,value\n")
+        fields, err = CSVSchemaReader.read_schema(csv)
+        assert err is None
+        assert len(fields) == 3
+        # With no sampled values at all, the reader keeps the type as unknown.
+        for f in fields:
+            assert f["type"] == "unknown"
+
+
+# ===================================================================
+# TestEntityResolver
+# ===================================================================
+
+
+class TestEntityResolver:
+    def test_matches_dataset_entity(self):
+        result = EntityResolver.resolve("occurrences.csv", SAMPLE_IMPORT_CONFIG)
+        assert result == "occurrences"
+
+    def test_matches_reference_entity(self):
+        result = EntityResolver.resolve("plots.csv", SAMPLE_IMPORT_CONFIG)
+        assert result == "plots"
+
+    def test_returns_none_for_unknown_file(self):
+        result = EntityResolver.resolve("unknown.csv", SAMPLE_IMPORT_CONFIG)
+        assert result is None
+
+    def test_returns_none_for_empty_config(self):
+        result = EntityResolver.resolve("test.csv", {})
+        assert result is None
+
+    def test_skips_derived_entities(self):
+        # taxons is DERIVED — has no path, shouldn't match anything
+        result = EntityResolver.resolve("taxons.csv", SAMPLE_IMPORT_CONFIG)
+        assert result is None
+
+    def test_returns_none_and_warns_on_duplicate_basename(self, caplog):
+        """When multiple entities share the same filename, return None."""
+        config = {
+            "entities": {
+                "datasets": {
+                    "occ_v1": {"connector": {"type": "file", "path": "v1/data.csv"}},
+                    "occ_v2": {"connector": {"type": "file", "path": "v2/data.csv"}},
+                },
+                "references": {},
+            }
+        }
+        with caplog.at_level(logging.WARNING):
+            result = EntityResolver.resolve("data.csv", config)
+        assert result is None
+        assert "Ambiguous" in caplog.text
+
+    def test_resolves_transform_only_csv_source(self):
+        """CSV sources defined only in transform.yml (not import.yml) should match."""
+        transform = [
+            {
+                "group_by": "plots",
+                "sources": [
+                    {
+                        "name": "plot_stats",
+                        "data": "imports/raw_plot_stats.csv",
+                        "grouping": "plots",
+                        "relation": {"plugin": "stats_loader", "key": "id"},
+                    }
+                ],
+            }
+        ]
+        result = EntityResolver.resolve(
+            "raw_plot_stats.csv", SAMPLE_IMPORT_CONFIG, transform
+        )
+        assert result == "plot_stats"
+
+    def test_resolves_auxiliary_source_from_import_config(self):
+        config = {
+            "entities": {"datasets": {}, "references": {}},
+            "auxiliary_sources": [
+                {
+                    "name": "shape_stats",
+                    "data": "imports/raw_shape_stats.csv",
+                    "grouping": "shapes",
+                    "relation": {"plugin": "stats_loader", "key": "id"},
+                }
+            ],
+        }
+        result = EntityResolver.resolve("raw_shape_stats.csv", config, [])
+        assert result == "shape_stats"
+
+    def test_does_not_match_vector_entity_path(self):
+        """VECTOR entities have paths but should be skipped by the resolver."""
+        config = {
+            "entities": {
+                "datasets": {},
+                "references": {
+                    "geo": {"connector": {"type": "vector", "path": "imports/geo.gpkg"}}
+                },
+            }
+        }
+        # VECTOR is not in the skip list of the resolver — it has a path.
+        # But check_compatibility will skip it via _get_skip_reason.
+        result = EntityResolver.resolve("geo.gpkg", config)
+        # The resolver WILL match it — the skip happens in check_compatibility
+        assert result == "geo"
+
+
+# ===================================================================
+# TestCompatibilityService
+# ===================================================================
+
+
+class TestCompatibilityService:
+    """Test the orchestrator with mocked file reads."""
+
+    def _make_service(self, tmp_path, import_cfg=None, transform_cfg=None):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        imports_dir = tmp_path / "imports"
+        imports_dir.mkdir(parents=True, exist_ok=True)
+
+        if import_cfg is not None:
+            (config_dir / "import.yml").write_text(
+                yaml.dump(import_cfg, default_flow_style=False)
+            )
+        if transform_cfg is not None:
+            (config_dir / "transform.yml").write_text(
+                yaml.dump(transform_cfg, default_flow_style=False)
+            )
+        return CompatibilityService(tmp_path)
+
+    def test_no_issues_when_all_columns_present(self, tmp_path):
+        csv = tmp_path / "imports" / "occurrences.csv"
+        service = self._make_service(
+            tmp_path,
+            import_cfg={
+                "entities": {
+                    "datasets": {
+                        "occurrences": {
+                            "connector": {
+                                "type": "file",
+                                "path": "imports/occurrences.csv",
+                            },
+                            "schema": {
+                                "id_field": "id",
+                                "fields": [{"name": "species", "type": "string"}],
+                            },
+                        }
+                    },
+                    "references": {},
+                }
+            },
+        )
+        pd.DataFrame({"id": [1, 2], "species": ["a", "b"]}).to_csv(csv, index=False)
+        report = service.check_compatibility("occurrences", "imports/occurrences.csv")
+        assert not report.has_blockers
+        assert not report.has_warnings
+        assert report.error is None
+
+    def test_detects_missing_column_blocks_import(self, tmp_path):
+        csv = tmp_path / "imports" / "occurrences.csv"
+        service = self._make_service(
+            tmp_path,
+            import_cfg={
+                "entities": {
+                    "datasets": {
+                        "occurrences": {
+                            "connector": {
+                                "type": "file",
+                                "path": "imports/occurrences.csv",
+                            },
+                            "schema": {
+                                "id_field": "id",
+                                "fields": [{"name": "species", "type": "string"}],
+                            },
+                        }
+                    },
+                    "references": {},
+                }
+            },
+        )
+        # CSV missing "species" column
+        pd.DataFrame({"id": [1, 2]}).to_csv(csv, index=False)
+        report = service.check_compatibility("occurrences", "imports/occurrences.csv")
+        assert report.has_blockers
+        missing = [i for i in report.impacts if i.level == ImpactLevel.BLOCKS_IMPORT]
+        assert any(i.column == "species" for i in missing)
+
+    def test_detects_missing_column_breaks_transform(self, tmp_path):
+        csv = tmp_path / "imports" / "occurrences.csv"
+        service = self._make_service(
+            tmp_path,
+            import_cfg={
+                "entities": {
+                    "datasets": {
+                        "occurrences": {
+                            "connector": {
+                                "type": "file",
+                                "path": "imports/occurrences.csv",
+                            },
+                            "schema": {"id_field": "id", "fields": []},
+                        }
+                    },
+                    "references": {},
+                }
+            },
+            transform_cfg=[
+                {
+                    "group_by": "taxons",
+                    "sources": [
+                        {
+                            "name": "occ",
+                            "data": "occurrences",
+                            "grouping": "taxons",
+                            "relation": {
+                                "plugin": "nested_set",
+                                "key": "id_taxonref",
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
+        # CSV missing id_taxonref
+        pd.DataFrame({"id": [1]}).to_csv(csv, index=False)
+        report = service.check_compatibility("occurrences", "imports/occurrences.csv")
+        breaking = [
+            i for i in report.impacts if i.level == ImpactLevel.BREAKS_TRANSFORM
+        ]
+        assert any(i.column == "id_taxonref" for i in breaking)
+
+    def test_detects_new_columns_as_opportunity(self, tmp_path):
+        csv = tmp_path / "imports" / "occurrences.csv"
+        service = self._make_service(
+            tmp_path,
+            import_cfg={
+                "entities": {
+                    "datasets": {
+                        "occurrences": {
+                            "connector": {
+                                "type": "file",
+                                "path": "imports/occurrences.csv",
+                            },
+                            "schema": {"id_field": "id", "fields": []},
+                        }
+                    },
+                    "references": {},
+                }
+            },
+        )
+        pd.DataFrame({"id": [1], "brand_new_col": ["x"]}).to_csv(csv, index=False)
+        report = service.check_compatibility("occurrences", "imports/occurrences.csv")
+        opportunities = [
+            i for i in report.impacts if i.level == ImpactLevel.OPPORTUNITY
+        ]
+        assert any(i.column == "brand_new_col" for i in opportunities)
+
+    def test_ignores_unknown_sample_type_warning(self, tmp_path):
+        service = self._make_service(tmp_path)
+        report = service._compare(
+            entity_name="occurrences",
+            file_path="imports/occurrences.csv",
+            new_schema={"plot_name": "unknown"},
+            old_schema={"plot_name": "string"},
+            config_refs={
+                "plot_name": [
+                    (
+                        "transform.yml > group plots > source occurrences > relation.key",
+                        ImpactLevel.BREAKS_TRANSFORM,
+                    )
+                ]
+            },
+            target_kind=TargetKind.IMPORT_ENTITY,
+        )
+        assert report.matched_columns[0].new_type == "unknown"
+        assert not report.has_warnings
+
+    def test_returns_error_for_unreadable_file(self, tmp_path):
+        service = self._make_service(
+            tmp_path,
+            import_cfg={
+                "entities": {
+                    "datasets": {
+                        "occurrences": {
+                            "connector": {
+                                "type": "file",
+                                "path": "imports/occurrences.csv",
+                            },
+                            "schema": {"id_field": "id", "fields": []},
+                        }
+                    },
+                    "references": {},
+                }
+            },
+        )
+        # File does not exist
+        report = service.check_compatibility("occurrences", "imports/occurrences.csv")
+        assert report.error is not None
+
+    def test_loads_registry_schema_from_configured_duckdb_path(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        db_dir = tmp_path / "db"
+        db_dir.mkdir(parents=True, exist_ok=True)
+
+        (config_dir / "config.yml").write_text(
+            yaml.dump({"database": {"path": "db/niamoto.duckdb"}})
+        )
+
+        db_path = db_dir / "niamoto.duckdb"
+        db = Database(str(db_path), read_only=False)
+        registry = EntityRegistry(db)
+        registry.register_entity(
+            name="occurrences",
+            kind=EntityKind.DATASET,
+            table_name="dataset_occurrences",
+            config={
+                "schema": {
+                    "id_field": "id",
+                    "fields": [
+                        {"name": "id", "type": "integer"},
+                        {"name": "species", "type": "string"},
+                    ],
+                }
+            },
+        )
+        db.close_db_session()
+        db.engine.dispose()
+
+        service = CompatibilityService(tmp_path)
+        schema = service._load_registry_schema("occurrences")
+        assert schema == {"id": "integer", "species": "string"}
+
+    def test_returns_empty_when_no_config(self, tmp_path):
+        (tmp_path / "imports").mkdir(parents=True)
+        csv = tmp_path / "imports" / "test.csv"
+        pd.DataFrame({"a": [1]}).to_csv(csv, index=False)
+        service = CompatibilityService(tmp_path)
+        report = service.check_compatibility("test", "imports/test.csv")
+        # No config → no refs → no blockers
+        assert not report.has_blockers
+
+    def test_rejects_path_outside_project(self, tmp_path):
+        service = self._make_service(
+            tmp_path,
+            import_cfg={
+                "entities": {
+                    "datasets": {
+                        "x": {
+                            "connector": {"type": "file", "path": "imports/x.csv"},
+                            "schema": {"id_field": "id", "fields": []},
+                        }
+                    },
+                    "references": {},
+                }
+            },
+        )
+        report = service.check_compatibility("x", "../../../tmp/evil.csv")
+        assert report.error is not None
+        assert "outside" in report.error.lower()
+
+    def test_check_all_skips_derived(self, tmp_path):
+        service = self._make_service(tmp_path, import_cfg=SAMPLE_IMPORT_CONFIG)
+        # Create CSV for file-based entities so they don't error
+        imports = tmp_path / "imports"
+        imports.mkdir(parents=True, exist_ok=True)
+        pd.DataFrame(
+            {
+                "id": [1],
+                "species": ["a"],
+                "dbh": [1.0],
+                "id_taxonref": [1],
+                "plot_name": ["p1"],
+            }
+        ).to_csv(imports / "occurrences.csv", index=False)
+        pd.DataFrame({"id_plot": [1], "geo_pt": ["POINT(0 0)"]}).to_csv(
+            imports / "plots.csv", index=False
+        )
+        reports = service.check_all()
+        taxon_report = next(r for r in reports if r.entity_name == "taxons")
+        assert taxon_report.skipped_reason is not None
+        assert "Derived" in taxon_report.skipped_reason
+
+    def test_check_all_skips_multi_feature(self, tmp_path):
+        cfg = {
+            "entities": {
+                "datasets": {
+                    "occ": {
+                        "connector": {"type": "file", "path": "imports/occ.csv"},
+                        "schema": {"id_field": "id", "fields": []},
+                    }
+                },
+                "references": {
+                    "shapes": {
+                        "connector": {
+                            "type": "file_multi_feature",
+                            "sources": [
+                                {
+                                    "name": "Provinces",
+                                    "path": "imports/prov.gpkg",
+                                    "name_field": "nom",
+                                }
+                            ],
+                        },
+                        "schema": {"fields": []},
+                    }
+                },
+            }
+        }
+        service = self._make_service(tmp_path, import_cfg=cfg)
+        imports = tmp_path / "imports"
+        imports.mkdir(parents=True, exist_ok=True)
+        pd.DataFrame({"id": [1]}).to_csv(imports / "occ.csv", index=False)
+        reports = service.check_all()
+        shapes_report = next(r for r in reports if r.entity_name == "shapes")
+        assert shapes_report.skipped_reason is not None
+        assert "V1" in shapes_report.skipped_reason
+
+    def test_check_compatibility_skips_vector_entity(self, tmp_path):
+        """check_compatibility must return skip for VECTOR entities (P2-B fix)."""
+        cfg = {
+            "entities": {
+                "datasets": {},
+                "references": {
+                    "geo": {
+                        "connector": {"type": "vector", "path": "imports/geo.gpkg"},
+                        "schema": {"fields": []},
+                    }
+                },
+            }
+        }
+        service = self._make_service(tmp_path, import_cfg=cfg)
+        (tmp_path / "imports").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "imports" / "geo.gpkg").write_bytes(b"fake")
+        report = service.check_compatibility("geo", "imports/geo.gpkg")
+        assert report.skipped_reason is not None
+        assert "V1" in report.skipped_reason
+
+    def test_check_all_includes_transform_sources(self, tmp_path):
+        service = self._make_service(
+            tmp_path,
+            import_cfg={"entities": {"datasets": {}, "references": {}}},
+            transform_cfg=[
+                {
+                    "group_by": "plots",
+                    "sources": [
+                        {
+                            "name": "plot_stats",
+                            "data": "imports/raw_plot_stats.csv",
+                            "grouping": "plots",
+                            "relation": {"plugin": "stats_loader", "key": "id"},
+                        }
+                    ],
+                }
+            ],
+        )
+        csv = tmp_path / "imports" / "raw_plot_stats.csv"
+        pd.DataFrame({"id": [1]}).to_csv(csv, index=False)
+
+        reports = service.check_all()
+        assert any(report.entity_name == "plot_stats" for report in reports)
+
+    def test_transform_source_missing_required_field_breaks_transform(self, tmp_path):
+        service = self._make_service(
+            tmp_path,
+            import_cfg={"entities": {"datasets": {}, "references": {}}},
+            transform_cfg=[
+                {
+                    "group_by": "plots",
+                    "sources": [
+                        {
+                            "name": "plot_stats",
+                            "data": "imports/raw_plot_stats.csv",
+                            "grouping": "plots",
+                            "relation": {
+                                "plugin": "stats_loader",
+                                "key": "id",
+                                "match_field": "plot_id",
+                            },
+                        }
+                    ],
+                    "widgets_data": {
+                        "plot_area": {
+                            "plugin": "direct_attribute",
+                            "params": {"source": "plot_stats", "field": "area_ha"},
+                        }
+                    },
+                }
+            ],
+        )
+        csv = tmp_path / "imports" / "raw_plot_stats.csv"
+        pd.DataFrame({"id": [1]}).to_csv(csv, index=False)
+
+        report = service.check_compatibility("plot_stats", "imports/raw_plot_stats.csv")
+        breaking = [
+            i for i in report.impacts if i.level == ImpactLevel.BREAKS_TRANSFORM
+        ]
+        assert {item.column for item in breaking} == {"area_ha", "plot_id"}
+
+    def test_transform_source_without_baseline_suppresses_opportunities(self, tmp_path):
+        service = self._make_service(
+            tmp_path,
+            import_cfg={"entities": {"datasets": {}, "references": {}}},
+            transform_cfg=[
+                {
+                    "group_by": "plots",
+                    "sources": [
+                        {
+                            "name": "plot_stats",
+                            "data": "imports/raw_plot_stats.csv",
+                            "grouping": "plots",
+                            "relation": {"plugin": "stats_loader", "key": "id"},
+                        }
+                    ],
+                }
+            ],
+        )
+        csv = tmp_path / "imports" / "raw_plot_stats.csv"
+        pd.DataFrame({"id": [1], "new_metric": [42]}).to_csv(csv, index=False)
+
+        report = service.check_compatibility("plot_stats", "imports/raw_plot_stats.csv")
+        assert not any(i.level == ImpactLevel.OPPORTUNITY for i in report.impacts)
+        assert report.info_message is not None
+        assert "First check" in report.info_message
+
+    def test_transform_source_class_object_series_requires_class_name(self, tmp_path):
+        service = self._make_service(
+            tmp_path,
+            import_cfg={"entities": {"datasets": {}, "references": {}}},
+            transform_cfg=[
+                {
+                    "group_by": "plots",
+                    "sources": [
+                        {
+                            "name": "plot_stats",
+                            "data": "imports/raw_plot_stats.csv",
+                            "grouping": "plots",
+                            "relation": {"plugin": "stats_loader", "key": "id"},
+                        }
+                    ],
+                    "widgets_data": {
+                        "fragmentation_distribution": {
+                            "plugin": "class_object_series_extractor",
+                            "params": {
+                                "source": "plot_stats",
+                                "class_object": "forest_fragmentation",
+                                "size_field": {
+                                    "input": "class_name",
+                                    "output": "sizes",
+                                },
+                                "value_field": {
+                                    "input": "class_value",
+                                    "output": "values",
+                                },
+                            },
+                        }
+                    },
+                }
+            ],
+        )
+        csv = tmp_path / "imports" / "raw_plot_stats.csv"
+        pd.DataFrame({"id": [1], "class_object": ["x"], "class_value": [0.5]}).to_csv(
+            csv, index=False
+        )
+
+        report = service.check_compatibility("plot_stats", "imports/raw_plot_stats.csv")
+
+        breaking = [
+            i for i in report.impacts if i.level == ImpactLevel.BREAKS_TRANSFORM
+        ]
+        assert {item.column for item in breaking} == {"class_name"}
+
+    def test_transform_source_class_object_field_aggregator_requires_class_object(
+        self, tmp_path
+    ):
+        service = self._make_service(
+            tmp_path,
+            import_cfg={"entities": {"datasets": {}, "references": {}}},
+            transform_cfg=[
+                {
+                    "group_by": "shapes",
+                    "sources": [
+                        {
+                            "name": "shape_stats",
+                            "data": "imports/raw_shape_stats.csv",
+                            "grouping": "shapes",
+                            "relation": {"plugin": "stats_loader", "key": "id"},
+                        }
+                    ],
+                    "widgets_data": {
+                        "general_info": {
+                            "plugin": "class_object_field_aggregator",
+                            "params": {
+                                "source": "shape_stats",
+                                "fields": [
+                                    {
+                                        "class_object": "land_area_ha",
+                                        "target": "land_area_ha",
+                                    }
+                                ],
+                            },
+                        }
+                    },
+                }
+            ],
+        )
+        csv = tmp_path / "imports" / "raw_shape_stats.csv"
+        pd.DataFrame({"id": [1], "class_value": [0.5]}).to_csv(csv, index=False)
+
+        report = service.check_compatibility(
+            "shape_stats", "imports/raw_shape_stats.csv"
+        )
+
+        breaking = [
+            i for i in report.impacts if i.level == ImpactLevel.BREAKS_TRANSFORM
+        ]
+        assert {item.column for item in breaking} == {"class_object"}
+
+    def test_missing_transform_source_registry_table_is_quiet(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        db_dir = tmp_path / "db"
+        db_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.yml").write_text(
+            yaml.dump({"database": {"path": "db/niamoto.duckdb"}})
+        )
+
+        db_path = db_dir / "niamoto.duckdb"
+        db = Database(str(db_path), read_only=False)
+        db.close_db_session()
+        db.engine.dispose()
+
+        service = CompatibilityService(tmp_path)
+        schema = service._load_transform_source_schema("plot_stats")
+        assert schema == {}
+
+    def test_loads_transform_source_schema_from_registry(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        db_dir = tmp_path / "db"
+        db_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.yml").write_text(
+            yaml.dump({"database": {"path": "db/niamoto.duckdb"}})
+        )
+
+        db_path = db_dir / "niamoto.duckdb"
+        db = Database(str(db_path), read_only=False)
+        registry = TransformSourceRegistry(db)
+        registry.register_source(
+            name="plot_stats",
+            path="imports/raw_plot_stats.csv",
+            grouping="plots",
+            config={
+                "schema": {
+                    "fields": [
+                        {"name": "id", "type": "integer"},
+                        {"name": "plot_id", "type": "string"},
+                    ]
+                }
+            },
+        )
+        db.close_db_session()
+        db.engine.dispose()
+
+        service = CompatibilityService(tmp_path)
+        schema = service._load_transform_source_schema("plot_stats")
+        assert schema == {"id": "integer", "plot_id": "string"}

--- a/tests/core/services/test_transformer.py
+++ b/tests/core/services/test_transformer.py
@@ -610,6 +610,65 @@ class TestTransformerService:
         assert "DROP TABLE IF EXISTS plots__staging" in drop_sql
         assert "plots" not in transformer_service._table_buffers
 
+    @patch("niamoto.core.services.compatibility.CSVSchemaReader.read_schema")
+    @patch("niamoto.core.imports.source_registry.TransformSourceRegistry")
+    def test_persist_transform_source_schemas_registers_file_sources(
+        self,
+        mock_registry_class,
+        mock_read_schema,
+        transformer_service,
+        tmp_path,
+    ):
+        imports_dir = tmp_path / "imports"
+        imports_dir.mkdir(parents=True, exist_ok=True)
+        source_file = imports_dir / "raw_plot_stats.csv"
+        source_file.write_text("id,plot_id\n1,P1\n", encoding="utf-8")
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        transformer_service.config.config_dir = str(config_dir)
+        mock_read_schema.return_value = (
+            [
+                {"name": "id", "type": "integer"},
+                {"name": "plot_id", "type": "string"},
+            ],
+            None,
+        )
+
+        registry_instance = Mock()
+        mock_registry_class.return_value = registry_instance
+
+        transformer_service._persist_transform_source_schemas(
+            [
+                {
+                    "group_by": "plots",
+                    "sources": [
+                        {
+                            "name": "plot_stats",
+                            "data": "imports/raw_plot_stats.csv",
+                            "grouping": "plots",
+                            "relation": {"plugin": "stats_loader", "key": "id"},
+                        }
+                    ],
+                }
+            ]
+        )
+
+        mock_read_schema.assert_called_once_with(source_file.resolve())
+        registry_instance.register_source.assert_called_once_with(
+            name="plot_stats",
+            path="imports/raw_plot_stats.csv",
+            grouping="plots",
+            config={
+                "schema": {
+                    "fields": [
+                        {"name": "id", "type": "integer"},
+                        {"name": "plot_id", "type": "string"},
+                    ]
+                }
+            },
+        )
+
     @patch("niamoto.core.services.transformer.CLI_CONTEXT", False)
     def test_transform_data_simple_mode(self, transformer_service, mock_db):
         """Test transform_data in simple mode (no CLI context).

--- a/tests/gui/api/routers/test_imports.py
+++ b/tests/gui/api/routers/test_imports.py
@@ -158,3 +158,93 @@ def test_process_generic_import_all_records_failure_event(monkeypatch, tmp_path)
     assert job["errors"]
     assert job["events"][-1]["kind"] == "error"
     assert "Import failed" in job["events"][-1]["message"]
+
+
+def test_impact_check_returns_skip_reason_for_vector_entity(monkeypatch, tmp_path):
+    work_dir = tmp_path
+    (work_dir / "config").mkdir()
+
+    class FakeCompatibilityService:
+        def __init__(self, working_directory):
+            self.working_directory = working_directory
+
+        def resolve_entity(self, filename: str):
+            assert filename == "geo.gpkg"
+            return "geo"
+
+        def check_compatibility(self, entity_name: str, file_path: str):
+            assert entity_name == "geo"
+            assert file_path == "imports/geo.gpkg"
+            return SimpleNamespace(
+                entity_name="geo",
+                matched_columns=[],
+                impacts=[],
+                error=None,
+                skipped_reason="Not supported in V1 (GPKG)",
+                has_blockers=False,
+                has_warnings=False,
+                has_opportunities=False,
+            )
+
+    monkeypatch.setattr(
+        "niamoto.gui.api.context.get_working_directory", lambda: work_dir
+    )
+    monkeypatch.setattr(
+        "niamoto.core.services.compatibility.CompatibilityService",
+        FakeCompatibilityService,
+    )
+
+    response = asyncio.run(
+        imports.impact_check(imports.ImpactCheckRequest(file_path="imports/geo.gpkg"))
+    )
+
+    assert response.entity_name == "geo"
+    assert response.skipped_reason == "Not supported in V1 (GPKG)"
+    assert response.error is None
+    assert response.impacts == []
+
+
+def test_impact_check_returns_info_message(monkeypatch, tmp_path):
+    work_dir = tmp_path
+    (work_dir / "config").mkdir()
+
+    class FakeCompatibilityService:
+        def __init__(self, working_directory):
+            self.working_directory = working_directory
+
+        def resolve_entity(self, filename: str):
+            assert filename == "raw_plot_stats.csv"
+            return "plot_stats"
+
+        def check_compatibility(self, entity_name: str, file_path: str):
+            assert entity_name == "plot_stats"
+            assert file_path == "imports/raw_plot_stats.csv"
+            return SimpleNamespace(
+                entity_name="plot_stats",
+                matched_columns=[],
+                impacts=[],
+                error=None,
+                skipped_reason=None,
+                info_message="First check for auxiliary source",
+                has_blockers=False,
+                has_warnings=False,
+                has_opportunities=False,
+            )
+
+    monkeypatch.setattr(
+        "niamoto.gui.api.context.get_working_directory", lambda: work_dir
+    )
+    monkeypatch.setattr(
+        "niamoto.core.services.compatibility.CompatibilityService",
+        FakeCompatibilityService,
+    )
+
+    response = asyncio.run(
+        imports.impact_check(
+            imports.ImpactCheckRequest(file_path="imports/raw_plot_stats.csv")
+        )
+    )
+
+    assert response.entity_name == "plot_stats"
+    assert response.info_message == "First check for auxiliary source"
+    assert response.error is None


### PR DESCRIPTION
## Summary
- add a pre-import impact check service with CLI, API, and ImportWizard integration
- extend coverage to transform auxiliary sources and plugin-aware reference collection for the current CSV workflows
- add regression tooling and documentation for auxiliary sources and the next GPKG slice

## Validation
- `uv run pytest tests/core/services/test_compatibility.py`

## Notes
- test-instance lab fixtures were kept out of the commit on purpose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-import impact analysis available via CLI (`import check`), API, and web interface
  * Validates data compatibility before import with color-coded severity reporting
  * Identifies blocking issues, breaking changes, warnings, and improvement opportunities
  * Non-blocking workflow allows proceeding with import or fixing data issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->