### PR TITLE
feat(dashboard): redesign pipeline overview

### DIFF
--- a/src/niamoto/gui/api/routers/pipeline.py
+++ b/src/niamoto/gui/api/routers/pipeline.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel, ValidationError
 
 from niamoto.core.plugins.models import HtmlExporterParams
@@ -323,8 +323,15 @@ def _compute_stage_status(items: list[EntityStatus]) -> str:
 
 
 @router.get("/history")
-async def get_pipeline_history(http_request: Request, limit: int = 10) -> list[dict]:
-    """Return the N most recent completed jobs (newest first)."""
+async def get_pipeline_history(
+    http_request: Request,
+    limit: int = Query(default=10, ge=1, le=100),
+) -> list[dict]:
+    """Return the N most recent completed jobs (newest first).
+
+    ``limit`` is clamped to [1, 100] to prevent unbounded slices or
+    surprising responses when ``limit=0`` or negative values are passed.
+    """
     try:
         job_store: Optional[JobFileStore] = resolve_job_store(http_request.app)
     except Exception:

--- a/src/niamoto/gui/api/routers/pipeline.py
+++ b/src/niamoto/gui/api/routers/pipeline.py
@@ -318,8 +318,18 @@ def _compute_stage_status(items: list[EntityStatus]) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Endpoint
+# Endpoints
 # ---------------------------------------------------------------------------
+
+
+@router.get("/history")
+async def get_pipeline_history(http_request: Request, limit: int = 10) -> list[dict]:
+    """Return the N most recent completed jobs (newest first)."""
+    try:
+        job_store: Optional[JobFileStore] = resolve_job_store(http_request.app)
+    except Exception:
+        return []
+    return job_store.get_history(limit=limit)
 
 
 @router.get("/status", response_model=PipelineStatusResponse)

--- a/src/niamoto/gui/ui/src/features/dashboard/components/ActivityFeed.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/ActivityFeed.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next"
+import type { TFunction } from "i18next"
 import { formatDistanceToNow } from "date-fns"
 import { enUS, fr } from "date-fns/locale"
 import { AlertTriangle, CheckCircle2, Database, Layers, Send } from "lucide-react"
@@ -58,46 +59,53 @@ function buildActivity(entries: JobHistoryEntry[] | undefined): ActivityItem[] {
     )
 }
 
-const TYPE_CONFIG = {
-  import: {
-    icon: <Database className="h-3.5 w-3.5" />,
-    label: "Import",
-    bg: "bg-blue-50 text-blue-600 dark:bg-blue-950/40 dark:text-blue-400",
-  },
-  transform: {
-    icon: <Layers className="h-3.5 w-3.5" />,
-    label: "Recalcul",
-    bg: "bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-400",
-  },
-  export: {
-    icon: <Send className="h-3.5 w-3.5" />,
-    label: "Export",
-    bg: "bg-emerald-50 text-emerald-600 dark:bg-emerald-950/40 dark:text-emerald-400",
-  },
-} as const
+type ActivityType = "import" | "transform" | "export"
+
+function typeConfig(type: ActivityType, t: TFunction) {
+  switch (type) {
+    case "import":
+      return {
+        icon: <Database className="h-3.5 w-3.5" />,
+        label: t("pipeline.activity.type_import", "Import"),
+        bg: "bg-blue-50 text-blue-600 dark:bg-blue-950/40 dark:text-blue-400",
+      }
+    case "transform":
+      return {
+        icon: <Layers className="h-3.5 w-3.5" />,
+        label: t("pipeline.activity.type_transform", "Recalcul"),
+        bg: "bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-400",
+      }
+    case "export":
+      return {
+        icon: <Send className="h-3.5 w-3.5" />,
+        label: t("pipeline.activity.type_export", "Export"),
+        bg: "bg-emerald-50 text-emerald-600 dark:bg-emerald-950/40 dark:text-emerald-400",
+      }
+  }
+}
 
 interface ActivityFeedProps {
   limit?: number
 }
 
-function statusMeta(status: string) {
+function statusMeta(status: string, t: TFunction) {
   if (status === "completed") {
     return {
       icon: <CheckCircle2 className="h-3 w-3 text-green-500" />,
-      label: "Terminé",
+      label: t("pipeline.activity.status_completed", "Terminé"),
     }
   }
 
   if (status === "failed") {
     return {
       icon: <AlertTriangle className="h-3 w-3 text-red-500" />,
-      label: "Échec",
+      label: t("pipeline.activity.status_failed", "Échec"),
     }
   }
 
   return {
     icon: <AlertTriangle className="h-3 w-3 text-amber-500" />,
-    label: "Interrompu",
+    label: t("pipeline.activity.status_interrupted", "Interrompu"),
   }
 }
 
@@ -119,8 +127,8 @@ export function ActivityFeed({ limit = 10 }: ActivityFeedProps) {
   return (
     <div className="divide-y divide-border/50">
       {items.map((item) => {
-        const cfg = TYPE_CONFIG[item.type]
-        const status = statusMeta(item.status)
+        const cfg = typeConfig(item.type, t)
+        const status = statusMeta(item.status, t)
         const timeAgo = formatDistanceToNow(new Date(item.last_run_at), {
           addSuffix: true,
           locale: dateLocale,

--- a/src/niamoto/gui/ui/src/features/dashboard/components/ActivityFeed.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/ActivityFeed.tsx
@@ -1,0 +1,126 @@
+import { useTranslation } from "react-i18next"
+import { formatDistanceToNow } from "date-fns"
+import { enUS, fr } from "date-fns/locale"
+import {
+  AlertCircle,
+  CheckCircle2,
+  Database,
+  Layers,
+  Loader2,
+  Send,
+  XCircle,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { JobHistoryEntry } from "@/hooks/usePipelineHistory"
+import { usePipelineHistory } from "@/hooks/usePipelineHistory"
+
+function jobIcon(type: string) {
+  switch (type) {
+    case "import":
+      return <Database className="h-3.5 w-3.5" />
+    case "transform":
+      return <Layers className="h-3.5 w-3.5" />
+    case "export":
+      return <Send className="h-3.5 w-3.5" />
+    default:
+      return <AlertCircle className="h-3.5 w-3.5" />
+  }
+}
+
+function statusIcon(status: string) {
+  switch (status) {
+    case "completed":
+      return <CheckCircle2 className="h-3 w-3 text-green-500" />
+    case "failed":
+      return <XCircle className="h-3 w-3 text-red-500" />
+    case "running":
+      return <Loader2 className="h-3 w-3 animate-spin text-blue-500" />
+    default:
+      return <AlertCircle className="h-3 w-3 text-muted-foreground" />
+  }
+}
+
+const JOB_TYPE_LABELS: Record<string, string> = {
+  import: "Import",
+  transform: "Recalculer",
+  export: "Export",
+}
+
+function ActivityEntry({ entry }: { entry: JobHistoryEntry }) {
+  const { i18n } = useTranslation()
+  const dateLocale = i18n.language === "fr" ? fr : enUS
+
+  const refDate = entry.completed_at ?? entry.started_at
+  const timeAgo = refDate
+    ? formatDistanceToNow(new Date(refDate), {
+        addSuffix: true,
+        locale: dateLocale,
+      })
+    : null
+
+  const isCompleted = entry.status === "completed"
+  const isFailed = entry.status === "failed"
+
+  return (
+    <div className="flex items-start gap-2.5 py-2">
+      <div
+        className={cn(
+          "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md",
+          isCompleted && "bg-green-50 text-green-600 dark:bg-green-950/40 dark:text-green-400",
+          isFailed && "bg-red-50 text-red-600 dark:bg-red-950/40 dark:text-red-400",
+          !isCompleted &&
+            !isFailed &&
+            "bg-muted text-muted-foreground",
+        )}
+      >
+        {jobIcon(entry.type)}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs font-medium">
+            {JOB_TYPE_LABELS[entry.type] ?? entry.type}
+          </span>
+          {entry.group_by && (
+            <span className="max-w-[100px] truncate text-[11px] text-muted-foreground">
+              · {entry.group_by}
+            </span>
+          )}
+          {statusIcon(entry.status)}
+        </div>
+        {timeAgo && (
+          <p className="text-[11px] text-muted-foreground">{timeAgo}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function ActivityFeed() {
+  const { t } = useTranslation("common")
+  const { data: history, isLoading } = usePipelineHistory(8)
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-4 text-xs text-muted-foreground">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        <span>{t("common.loading", "Chargement...")}</span>
+      </div>
+    )
+  }
+
+  if (!history || history.length === 0) {
+    return (
+      <p className="py-4 text-center text-sm text-muted-foreground">
+        {t("pipeline.no_activity", "Aucune activité récente")}
+      </p>
+    )
+  }
+
+  return (
+    <div className="divide-y divide-border/50">
+      {history.map((entry) => (
+        <ActivityEntry key={entry.id} entry={entry} />
+      ))}
+    </div>
+  )
+}

--- a/src/niamoto/gui/ui/src/features/dashboard/components/ActivityFeed.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/ActivityFeed.tsx
@@ -1,114 +1,81 @@
 import { useTranslation } from "react-i18next"
 import { formatDistanceToNow } from "date-fns"
 import { enUS, fr } from "date-fns/locale"
-import {
-  AlertCircle,
-  CheckCircle2,
-  Database,
-  Layers,
-  Loader2,
-  Send,
-  XCircle,
-} from "lucide-react"
-import { cn } from "@/lib/utils"
-import type { JobHistoryEntry } from "@/hooks/usePipelineHistory"
-import { usePipelineHistory } from "@/hooks/usePipelineHistory"
+import { CheckCircle2, Database, Layers, Send } from "lucide-react"
+import type { StageStatus } from "@/hooks/usePipelineStatus"
 
-function jobIcon(type: string) {
-  switch (type) {
-    case "import":
-      return <Database className="h-3.5 w-3.5" />
-    case "transform":
-      return <Layers className="h-3.5 w-3.5" />
-    case "export":
-      return <Send className="h-3.5 w-3.5" />
-    default:
-      return <AlertCircle className="h-3.5 w-3.5" />
-  }
+interface ActivityItem {
+  type: "import" | "transform" | "export"
+  last_run_at: string
+  duration_s: number | null
 }
 
-function statusIcon(status: string) {
-  switch (status) {
-    case "completed":
-      return <CheckCircle2 className="h-3 w-3 text-green-500" />
-    case "failed":
-      return <XCircle className="h-3 w-3 text-red-500" />
-    case "running":
-      return <Loader2 className="h-3 w-3 animate-spin text-blue-500" />
-    default:
-      return <AlertCircle className="h-3 w-3 text-muted-foreground" />
-  }
-}
+function buildActivity(
+  data: StageStatus | undefined,
+  groups: StageStatus | undefined,
+  publication: StageStatus | undefined,
+): ActivityItem[] {
+  const items: ActivityItem[] = []
 
-const JOB_TYPE_LABELS: Record<string, string> = {
-  import: "Import",
-  transform: "Recalculer",
-  export: "Export",
-}
-
-function ActivityEntry({ entry }: { entry: JobHistoryEntry }) {
-  const { i18n } = useTranslation()
-  const dateLocale = i18n.language === "fr" ? fr : enUS
-
-  const refDate = entry.completed_at ?? entry.started_at
-  const timeAgo = refDate
-    ? formatDistanceToNow(new Date(refDate), {
-        addSuffix: true,
-        locale: dateLocale,
+  const add = (
+    type: ActivityItem["type"],
+    stage: StageStatus | undefined,
+  ) => {
+    if (
+      stage?.last_run_at &&
+      stage.status !== "never_run" &&
+      stage.status !== "unconfigured"
+    ) {
+      items.push({
+        type,
+        last_run_at: stage.last_run_at,
+        duration_s: stage.last_job_duration_s ?? null,
       })
-    : null
+    }
+  }
 
-  const isCompleted = entry.status === "completed"
-  const isFailed = entry.status === "failed"
+  add("import", data)
+  add("transform", groups)
+  add("export", publication)
 
-  return (
-    <div className="flex items-start gap-2.5 py-2">
-      <div
-        className={cn(
-          "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md",
-          isCompleted && "bg-green-50 text-green-600 dark:bg-green-950/40 dark:text-green-400",
-          isFailed && "bg-red-50 text-red-600 dark:bg-red-950/40 dark:text-red-400",
-          !isCompleted &&
-            !isFailed &&
-            "bg-muted text-muted-foreground",
-        )}
-      >
-        {jobIcon(entry.type)}
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5">
-          <span className="text-xs font-medium">
-            {JOB_TYPE_LABELS[entry.type] ?? entry.type}
-          </span>
-          {entry.group_by && (
-            <span className="max-w-[100px] truncate text-[11px] text-muted-foreground">
-              · {entry.group_by}
-            </span>
-          )}
-          {statusIcon(entry.status)}
-        </div>
-        {timeAgo && (
-          <p className="text-[11px] text-muted-foreground">{timeAgo}</p>
-        )}
-      </div>
-    </div>
+  // Tri anti-chronologique
+  return items.sort(
+    (a, b) =>
+      new Date(b.last_run_at).getTime() - new Date(a.last_run_at).getTime(),
   )
 }
 
-export function ActivityFeed() {
-  const { t } = useTranslation("common")
-  const { data: history, isLoading } = usePipelineHistory(8)
+const TYPE_CONFIG = {
+  import: {
+    icon: <Database className="h-3.5 w-3.5" />,
+    label: "Import",
+    bg: "bg-blue-50 text-blue-600 dark:bg-blue-950/40 dark:text-blue-400",
+  },
+  transform: {
+    icon: <Layers className="h-3.5 w-3.5" />,
+    label: "Recalcul",
+    bg: "bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-400",
+  },
+  export: {
+    icon: <Send className="h-3.5 w-3.5" />,
+    label: "Export",
+    bg: "bg-emerald-50 text-emerald-600 dark:bg-emerald-950/40 dark:text-emerald-400",
+  },
+} as const
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center gap-2 py-4 text-xs text-muted-foreground">
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        <span>{t("common.loading", "Chargement...")}</span>
-      </div>
-    )
-  }
+interface ActivityFeedProps {
+  data: StageStatus | undefined
+  groups: StageStatus | undefined
+  publication: StageStatus | undefined
+}
 
-  if (!history || history.length === 0) {
+export function ActivityFeed({ data, groups, publication }: ActivityFeedProps) {
+  const { t, i18n } = useTranslation("common")
+  const dateLocale = i18n.language === "fr" ? fr : enUS
+
+  const items = buildActivity(data, groups, publication)
+
+  if (items.length === 0) {
     return (
       <p className="py-4 text-center text-sm text-muted-foreground">
         {t("pipeline.no_activity", "Aucune activité récente")}
@@ -118,9 +85,35 @@ export function ActivityFeed() {
 
   return (
     <div className="divide-y divide-border/50">
-      {history.map((entry) => (
-        <ActivityEntry key={entry.id} entry={entry} />
-      ))}
+      {items.map((item) => {
+        const cfg = TYPE_CONFIG[item.type]
+        const timeAgo = formatDistanceToNow(new Date(item.last_run_at), {
+          addSuffix: true,
+          locale: dateLocale,
+        })
+
+        return (
+          <div key={item.type} className="flex items-start gap-2.5 py-2">
+            <div
+              className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md ${cfg.bg}`}
+            >
+              {cfg.icon}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs font-medium">{cfg.label}</span>
+                <CheckCircle2 className="h-3 w-3 text-green-500" />
+              </div>
+              <p className="text-[11px] text-muted-foreground">
+                {timeAgo}
+                {item.duration_s != null && (
+                  <span className="ml-1.5 opacity-70">· {item.duration_s}s</span>
+                )}
+              </p>
+            </div>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/niamoto/gui/ui/src/features/dashboard/components/ActivityFeed.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/ActivityFeed.tsx
@@ -1,48 +1,61 @@
 import { useTranslation } from "react-i18next"
 import { formatDistanceToNow } from "date-fns"
 import { enUS, fr } from "date-fns/locale"
-import { CheckCircle2, Database, Layers, Send } from "lucide-react"
-import type { StageStatus } from "@/hooks/usePipelineStatus"
+import { AlertTriangle, CheckCircle2, Database, Layers, Send } from "lucide-react"
+import { usePipelineHistory, type JobHistoryEntry } from "@/hooks/usePipelineHistory"
 
 interface ActivityItem {
+  id: string
   type: "import" | "transform" | "export"
   last_run_at: string
+  status: string
+  message: string | null
   duration_s: number | null
 }
 
-function buildActivity(
-  data: StageStatus | undefined,
-  groups: StageStatus | undefined,
-  publication: StageStatus | undefined,
-): ActivityItem[] {
-  const items: ActivityItem[] = []
+function isTrackedHistoryEntry(
+  entry: JobHistoryEntry,
+): entry is JobHistoryEntry & {
+  type: ActivityItem["type"]
+  completed_at: string
+} {
+  return (
+    !!entry.completed_at &&
+    (entry.type === "import" ||
+      entry.type === "transform" ||
+      entry.type === "export")
+  )
+}
 
-  const add = (
-    type: ActivityItem["type"],
-    stage: StageStatus | undefined,
-  ) => {
-    if (
-      stage?.last_run_at &&
-      stage.status !== "never_run" &&
-      stage.status !== "unconfigured"
-    ) {
-      items.push({
-        type,
-        last_run_at: stage.last_run_at,
-        duration_s: stage.last_job_duration_s ?? null,
-      })
-    }
+function buildActivity(entries: JobHistoryEntry[] | undefined): ActivityItem[] {
+  if (!entries) {
+    return []
   }
 
-  add("import", data)
-  add("transform", groups)
-  add("export", publication)
-
-  // Tri anti-chronologique
-  return items.sort(
-    (a, b) =>
-      new Date(b.last_run_at).getTime() - new Date(a.last_run_at).getTime(),
-  )
+  return entries
+    .filter(isTrackedHistoryEntry)
+    .map((entry) => ({
+      id: entry.id,
+      type: entry.type,
+      last_run_at: entry.completed_at,
+      status: entry.status,
+      message: entry.message ?? null,
+      duration_s:
+        entry.started_at && entry.completed_at
+          ? Math.max(
+              0,
+              Math.round(
+                (new Date(entry.completed_at).getTime() -
+                  new Date(entry.started_at).getTime()) /
+                  1000,
+              ),
+            )
+          : null,
+    }))
+    .sort(
+      (a, b) =>
+        new Date(b.last_run_at).getTime() - new Date(a.last_run_at).getTime(),
+    )
 }
 
 const TYPE_CONFIG = {
@@ -64,16 +77,36 @@ const TYPE_CONFIG = {
 } as const
 
 interface ActivityFeedProps {
-  data: StageStatus | undefined
-  groups: StageStatus | undefined
-  publication: StageStatus | undefined
+  limit?: number
 }
 
-export function ActivityFeed({ data, groups, publication }: ActivityFeedProps) {
+function statusMeta(status: string) {
+  if (status === "completed") {
+    return {
+      icon: <CheckCircle2 className="h-3 w-3 text-green-500" />,
+      label: "Terminé",
+    }
+  }
+
+  if (status === "failed") {
+    return {
+      icon: <AlertTriangle className="h-3 w-3 text-red-500" />,
+      label: "Échec",
+    }
+  }
+
+  return {
+    icon: <AlertTriangle className="h-3 w-3 text-amber-500" />,
+    label: "Interrompu",
+  }
+}
+
+export function ActivityFeed({ limit = 10 }: ActivityFeedProps) {
   const { t, i18n } = useTranslation("common")
   const dateLocale = i18n.language === "fr" ? fr : enUS
+  const { data: history } = usePipelineHistory(limit)
 
-  const items = buildActivity(data, groups, publication)
+  const items = buildActivity(history)
 
   if (items.length === 0) {
     return (
@@ -87,13 +120,14 @@ export function ActivityFeed({ data, groups, publication }: ActivityFeedProps) {
     <div className="divide-y divide-border/50">
       {items.map((item) => {
         const cfg = TYPE_CONFIG[item.type]
+        const status = statusMeta(item.status)
         const timeAgo = formatDistanceToNow(new Date(item.last_run_at), {
           addSuffix: true,
           locale: dateLocale,
         })
 
         return (
-          <div key={item.type} className="flex items-start gap-2.5 py-2">
+          <div key={item.id} className="flex items-start gap-2.5 py-2">
             <div
               className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md ${cfg.bg}`}
             >
@@ -102,7 +136,8 @@ export function ActivityFeed({ data, groups, publication }: ActivityFeedProps) {
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-1.5">
                 <span className="text-xs font-medium">{cfg.label}</span>
-                <CheckCircle2 className="h-3 w-3 text-green-500" />
+                {status.icon}
+                <span className="text-[11px] text-muted-foreground">{status.label}</span>
               </div>
               <p className="text-[11px] text-muted-foreground">
                 {timeAgo}
@@ -110,6 +145,11 @@ export function ActivityFeed({ data, groups, publication }: ActivityFeedProps) {
                   <span className="ml-1.5 opacity-70">· {item.duration_s}s</span>
                 )}
               </p>
+              {item.message && (
+                <p className="truncate text-[11px] text-muted-foreground">
+                  {item.message}
+                </p>
+              )}
             </div>
           </div>
         )

--- a/src/niamoto/gui/ui/src/features/dashboard/components/DashboardView.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/DashboardView.tsx
@@ -26,11 +26,11 @@ export function DashboardView() {
 
   const { data, groups, site, publication, running_job } = pipeline
 
-  // Statut global résumé en une ligne
   const allFresh =
     data.status === "fresh" &&
     (groups.status === "fresh" || groups.status === "unconfigured") &&
-    publication.status !== "stale"
+    site.status === "fresh" &&
+    publication.status === "fresh"
 
   const hasStale =
     data.status === "stale" ||
@@ -103,6 +103,7 @@ export function DashboardView() {
       <PipelineBar
         data={data}
         groups={groups}
+        site={site}
         publication={publication}
       />
 
@@ -146,11 +147,7 @@ export function DashboardView() {
             </CardTitle>
           </CardHeader>
           <CardContent className="px-4 pb-4 pt-0">
-            <ActivityFeed
-              data={data}
-              groups={groups}
-              publication={publication}
-            />
+            <ActivityFeed />
           </CardContent>
         </Card>
       </div>

--- a/src/niamoto/gui/ui/src/features/dashboard/components/DashboardView.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/DashboardView.tsx
@@ -117,6 +117,7 @@ export function DashboardView() {
           siteStatus={site.status}
           publicationStatus={publication.status}
           isRunning={!!running_job}
+          hasEntities={(data.summary?.entities?.length ?? 0) > 0}
         />
       </div>
 

--- a/src/niamoto/gui/ui/src/features/dashboard/components/DashboardView.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/DashboardView.tsx
@@ -146,7 +146,11 @@ export function DashboardView() {
             </CardTitle>
           </CardHeader>
           <CardContent className="px-4 pb-4 pt-0">
-            <ActivityFeed />
+            <ActivityFeed
+              data={data}
+              groups={groups}
+              publication={publication}
+            />
           </CardContent>
         </Card>
       </div>

--- a/src/niamoto/gui/ui/src/features/dashboard/components/DashboardView.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/DashboardView.tsx
@@ -1,243 +1,154 @@
-import { useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { AlertTriangle, Database, Globe, Layers, Loader2, RefreshCw, Send } from "lucide-react"
-
+import { Loader2 } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
 import { usePipelineStatus } from "@/hooks/usePipelineStatus"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { StageCard } from "./StageCard"
-import { DataSummary } from "./summaries/DataSummary"
-import { CollectionsSummary } from "./summaries/CollectionsSummary"
-import { SiteSummary } from "./summaries/SiteSummary"
-import { PublicationSummary } from "./summaries/PublicationSummary"
-import { CardEntrance, CardEntranceItem } from "@/components/motion/CardEntrance"
+import { PipelineBar } from "./PipelineBar"
+import { QuickActions } from "./QuickActions"
+import { KeyStats } from "./KeyStats"
+import { ActivityFeed } from "./ActivityFeed"
 
 export function DashboardView() {
   const { t } = useTranslation("common")
-  const navigate = useNavigate()
   const { data: pipeline, isLoading, isFetching } = usePipelineStatus()
 
   if (!pipeline) {
     if (!isLoading) return null
-
     return (
       <div className="flex h-full items-center justify-center p-4">
         <div className="flex items-center gap-3 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
-          <span>{t("pipeline.dashboard.loading", "Loading dashboard status...")}</span>
+          <span>{t("pipeline.dashboard.loading", "Chargement du tableau de bord...")}</span>
         </div>
       </div>
     )
   }
 
-  const hasStale =
-    pipeline.data.status === "stale" ||
-    pipeline.groups.status === "stale" ||
-    pipeline.site.status === "stale" ||
-    pipeline.publication.status === "stale"
-  const hasPendingFirstRun =
-    pipeline.groups.status === "never_run" ||
-    pipeline.site.status === "never_run" ||
-    pipeline.publication.status === "never_run"
+  const { data, groups, site, publication, running_job } = pipeline
 
-  const staleGroups =
-    pipeline.groups.items?.filter((item) => item.status === "stale") ?? []
-  const neverRunGroups =
-    pipeline.groups.items?.filter((item) => item.status === "never_run") ?? []
+  // Statut global résumé en une ligne
+  const allFresh =
+    data.status === "fresh" &&
+    (groups.status === "fresh" || groups.status === "unconfigured") &&
+    publication.status !== "stale"
+
+  const hasStale =
+    data.status === "stale" ||
+    groups.status === "stale" ||
+    publication.status === "stale"
+
+  const globalLabel = running_job
+    ? t("pipeline.dashboard.running", "Pipeline en cours d'exécution")
+    : allFresh
+      ? t("pipeline.dashboard.fresh_subtitle", "Tout est à jour")
+      : hasStale
+        ? t("pipeline.dashboard.stale_subtitle", "Des mises à jour sont nécessaires")
+        : t("pipeline.dashboard.pending_subtitle", "Étapes initiales en attente")
+
+  const globalColor = running_job
+    ? "text-blue-600 dark:text-blue-400"
+    : allFresh
+      ? "text-green-600 dark:text-green-400"
+      : hasStale
+        ? "text-amber-600 dark:text-amber-400"
+        : "text-muted-foreground"
 
   return (
-    <div className="space-y-4 p-4">
+    <div className="flex flex-col gap-5 p-4 pb-6">
+      {/* ── En-tête ─────────────────────────────────────────────── */}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold">
             {t("pipeline.dashboard.title", "Dashboard")}
           </h1>
-          {hasStale ? (
-            <p className="text-amber-600 dark:text-amber-400">
-              {t("pipeline.dashboard.stale_subtitle", "Updates are needed")}
-            </p>
-          ) : hasPendingFirstRun ? (
-            <p className="text-muted-foreground">
-              {t(
-                "pipeline.dashboard.pending_subtitle",
-                "Initial steps are still pending",
-              )}
-            </p>
-          ) : (
-            <p className="text-green-600 dark:text-green-400">
-              {t(
-                "pipeline.dashboard.fresh_subtitle",
-                "Everything is up to date",
-              )}
-            </p>
-          )}
-          {isFetching && (
-            <p className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-              <Loader2 className="h-3 w-3 animate-spin" />
-              {t("pipeline.dashboard.refreshing", "Refreshing status...")}
-            </p>
-          )}
+          <p className={globalColor}>{globalLabel}</p>
         </div>
-
-        {hasStale && (
-          <Button
-            className="gap-2"
-            onClick={() => {
-              if (pipeline.groups.status === "stale") navigate("/groups")
-              else if (pipeline.site.status === "stale")
-                navigate("/publish")
-              else if (pipeline.publication.status === "stale")
-                navigate("/publish?panel=destinations")
-              else navigate("/sources/import")
-            }}
-          >
-            <RefreshCw className="h-4 w-4" />
-            {t("pipeline.dashboard.update_all", "Update")}
-          </Button>
+        {isFetching && !running_job && (
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground/50" />
         )}
       </div>
 
-      {staleGroups.length > 0 && (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950/30">
-          <div className="flex items-start gap-3">
-            <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-600 dark:text-amber-400" />
-            <div className="flex-1">
-              <p className="font-medium text-amber-800 dark:text-amber-300">
-                {t("pipeline.cascade.title", "Update cascade")}
+      {/* ── Job en cours ─────────────────────────────────────────── */}
+      {running_job && (
+        <Card className="border-blue-200 bg-blue-50/50 dark:border-blue-800 dark:bg-blue-950/20">
+          <CardContent className="flex items-center gap-3 p-4">
+            <Loader2 className="h-4 w-4 shrink-0 animate-spin text-blue-500" />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium">
+                {running_job.type === "import" &&
+                  t("pipeline.running_import", "Import en cours...")}
+                {running_job.type === "transform" &&
+                  t("pipeline.running_transform", "Calcul en cours...")}
+                {running_job.type === "export" &&
+                  t("pipeline.running_export", "Construction en cours...")}
               </p>
-              <p className="mt-1 text-sm text-amber-700 dark:text-amber-400">
-                {t(
-                  "pipeline.cascade.description",
-                  "Recalculate {{count}} group(s) → Rebuild site → Publish",
-                  { count: staleGroups.length },
-                )}
-              </p>
+              {running_job.message && (
+                <p className="truncate text-xs text-muted-foreground">
+                  {running_job.message}
+                </p>
+              )}
+              <Progress
+                value={running_job.progress}
+                className="mt-2 h-1.5"
+              />
             </div>
-          </div>
-        </div>
+            <span className="shrink-0 text-sm font-semibold tabular-nums text-blue-600 dark:text-blue-400">
+              {running_job.progress}%
+            </span>
+          </CardContent>
+        </Card>
       )}
 
-      {!hasStale && neverRunGroups.length > 0 && (
-        <div className="rounded-lg border border-sky-200 bg-sky-50 p-4 dark:border-sky-900 dark:bg-sky-950/30">
-          <div className="flex items-start gap-3">
-            <RefreshCw className="mt-0.5 h-5 w-5 text-sky-600 dark:text-sky-400" />
-            <div className="flex-1">
-              <p className="font-medium text-sky-800 dark:text-sky-300">
-                {t("pipeline.first_run.title", "First calculations")}
-              </p>
-              <p className="mt-1 text-sm text-sky-700 dark:text-sky-400">
-                {t(
-                  "pipeline.first_run.description",
-                  "Calculate {{count}} collection(s) to initialize results before building and publishing.",
-                  { count: neverRunGroups.length },
-                )}
-              </p>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* ── Barre pipeline ──────────────────────────────────────── */}
+      <PipelineBar
+        data={data}
+        groups={groups}
+        publication={publication}
+      />
 
-      <CardEntrance className="grid gap-4 sm:grid-cols-2">
-        <CardEntranceItem>
-          <StageCard
-            icon={<Database className="h-5 w-5 text-blue-600 dark:text-blue-400" />}
-            title={t("sidebar.nav.data", "Data")}
-            stage={pipeline.data}
-            path="/sources"
-            borderColor="border-l-blue-500"
-            iconBgClass="bg-blue-50 dark:bg-blue-950/40"
-            actionLabel={t("pipeline.action_import", "Import")}
-            onAction={() => navigate("/sources/import")}
-          >
-            <DataSummary summary={pipeline.data.summary} />
-          </StageCard>
-        </CardEntranceItem>
+      {/* ── Actions rapides ─────────────────────────────────────── */}
+      <div>
+        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {t("pipeline.quick_actions", "Actions rapides")}
+        </p>
+        <QuickActions
+          dataStatus={data.status}
+          groupsStatus={groups.status}
+          siteStatus={site.status}
+          publicationStatus={publication.status}
+          isRunning={!!running_job}
+        />
+      </div>
 
-        <CardEntranceItem>
-          <StageCard
-            icon={<Layers className="h-5 w-5 text-amber-600 dark:text-amber-400" />}
-            title={t("sidebar.nav.collections", "Collections")}
-            stage={pipeline.groups}
-            path="/groups"
-            borderColor="border-l-amber-500"
-            iconBgClass="bg-amber-50 dark:bg-amber-950/40"
-            actionLabel={t("pipeline.action_recalculate", "Recalculate")}
-            onAction={() => navigate("/groups")}
-            showActionWhen={["stale", "never_run"]}
-          >
-            <CollectionsSummary
-              status={pipeline.groups.status}
-              groups={pipeline.groups.summary?.groups}
-              items={
-                pipeline.groups.items?.map((item) => ({
-                  name: item.name,
-                  status: item.status,
-                })) ?? []
-              }
+      {/* ── Bas : Stats + Activité ──────────────────────────────── */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-2 pt-4">
+            <CardTitle className="text-sm font-semibold">
+              {t("pipeline.key_stats", "Données")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="px-4 pb-4 pt-0">
+            <KeyStats
+              dataSummary={data.summary}
+              groupsSummary={groups.summary}
+              siteSummary={site.summary}
+              pubSummary={publication.summary}
             />
-          </StageCard>
-        </CardEntranceItem>
+          </CardContent>
+        </Card>
 
-        <CardEntranceItem>
-          <StageCard
-            icon={<Globe className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />}
-            title={t("sidebar.nav.site", "Site")}
-            stage={pipeline.site}
-            path="/site"
-            borderColor="border-l-emerald-500"
-            iconBgClass="bg-emerald-50 dark:bg-emerald-950/40"
-            actionLabel={t("pipeline.action_configure", "Configure")}
-            onAction={() => navigate("/site/pages")}
-          >
-            <SiteSummary summary={pipeline.site.summary} />
-          </StageCard>
-        </CardEntranceItem>
-
-        <CardEntranceItem>
-          <StageCard
-            icon={<Send className="h-5 w-5 text-orange-600 dark:text-orange-400" />}
-            title={t("sidebar.nav.publish", "Publish")}
-            stage={pipeline.publication}
-            path="/publish"
-            borderColor="border-l-orange-500"
-            iconBgClass="bg-orange-50 dark:bg-orange-950/40"
-            actionLabel={t("pipeline.action_rebuild", "Rebuild")}
-            onAction={() => navigate("/publish")}
-          >
-            <PublicationSummary summary={pipeline.publication.summary} />
-          </StageCard>
-        </CardEntranceItem>
-      </CardEntrance>
-
-      {pipeline.running_job && (
-        <CardEntrance>
-          <CardEntranceItem>
-            <Card className="border-blue-200 dark:border-blue-800">
-              <CardContent className="flex items-center gap-3 p-4">
-                <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
-                <div className="flex-1">
-                  <p className="font-medium">
-                    {pipeline.running_job.type === "import" &&
-                      t("pipeline.running_import", "Import en cours...")}
-                    {pipeline.running_job.type === "transform" &&
-                      t("pipeline.running_transform", "Calcul en cours...")}
-                    {pipeline.running_job.type === "export" &&
-                      t("pipeline.running_export", "Construction en cours...")}
-                  </p>
-                  {pipeline.running_job.message && (
-                    <p className="text-sm text-muted-foreground">
-                      {pipeline.running_job.message}
-                    </p>
-                  )}
-                </div>
-                <span className="text-sm font-medium text-blue-600 dark:text-blue-400">
-                  {pipeline.running_job.progress}%
-                </span>
-              </CardContent>
-            </Card>
-          </CardEntranceItem>
-        </CardEntrance>
-      )}
+        <Card>
+          <CardHeader className="pb-2 pt-4">
+            <CardTitle className="text-sm font-semibold">
+              {t("pipeline.recent_activity", "Activité récente")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="px-4 pb-4 pt-0">
+            <ActivityFeed />
+          </CardContent>
+        </Card>
+      </div>
     </div>
   )
 }

--- a/src/niamoto/gui/ui/src/features/dashboard/components/KeyStats.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/KeyStats.tsx
@@ -1,0 +1,121 @@
+import { useTranslation } from "react-i18next"
+import { Database, Layers, Map } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { StageSummary } from "@/hooks/usePipelineStatus"
+
+interface StatRowProps {
+  icon: React.ReactNode
+  label: string
+  value: string | number
+  sub?: string
+  highlight?: boolean
+}
+
+function StatRow({ icon, label, value, sub, highlight }: StatRowProps) {
+  return (
+    <div className="flex items-center justify-between py-2">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div className="text-right">
+        <span
+          className={cn(
+            "text-sm font-semibold tabular-nums",
+            highlight && "text-foreground",
+          )}
+        >
+          {typeof value === "number" ? value.toLocaleString() : value}
+        </span>
+        {sub && (
+          <span className="ml-1.5 text-xs text-muted-foreground">{sub}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface KeyStatsProps {
+  dataSummary: StageSummary | null | undefined
+  groupsSummary: StageSummary | null | undefined
+  siteSummary: StageSummary | null | undefined
+  pubSummary: StageSummary | null | undefined
+}
+
+export function KeyStats({
+  dataSummary,
+  groupsSummary,
+  siteSummary,
+  pubSummary,
+}: KeyStatsProps) {
+  const { t } = useTranslation("common")
+
+  const entities = dataSummary?.entities ?? []
+  const groups = groupsSummary?.groups ?? []
+  const htmlPageCount = pubSummary?.html_page_count ?? null
+  const totalSizeMb = pubSummary?.total_size_mb ?? null
+
+  // Total lignes tous types confondus
+  const totalRows = entities.reduce((acc, e) => acc + e.row_count, 0)
+
+  const hasAny = totalRows > 0 || groups.length > 0
+
+  if (!hasAny) {
+    return (
+      <p className="py-4 text-center text-sm text-muted-foreground">
+        {t("pipeline.no_data_yet", "Aucune donnée importée")}
+      </p>
+    )
+  }
+
+  return (
+    <div className="divide-y divide-border/50">
+      {/* Entités importées */}
+      {entities.map((entity) => (
+        <StatRow
+          key={entity.name}
+          icon={<Database className="h-3.5 w-3.5" />}
+          label={entity.name}
+          value={entity.row_count}
+          sub={t("pipeline.rows", "lignes")}
+          highlight={entity.row_count > 0}
+        />
+      ))}
+
+      {/* Groupes */}
+      {groups.length > 0 && (
+        <StatRow
+          icon={<Layers className="h-3.5 w-3.5" />}
+          label={t("sidebar.nav.collections", "Collections")}
+          value={groups.length}
+          sub={t("pipeline.groups_unit", "groupes")}
+          highlight
+        />
+      )}
+
+      {/* Site */}
+      {siteSummary?.page_count != null && siteSummary.page_count > 0 && (
+        <StatRow
+          icon={<Map className="h-3.5 w-3.5" />}
+          label={t("sidebar.nav.site", "Site")}
+          value={siteSummary.page_count}
+          sub={t("pipeline.pages_unit", "pages configurées")}
+        />
+      )}
+
+      {/* Publication */}
+      {htmlPageCount != null && (
+        <StatRow
+          icon={<Map className="h-3.5 w-3.5" />}
+          label={t("sidebar.nav.publish", "Publication")}
+          value={htmlPageCount}
+          sub={
+            totalSizeMb != null
+              ? `pages HTML · ${totalSizeMb} Mo`
+              : "pages HTML"
+          }
+        />
+      )}
+    </div>
+  )
+}

--- a/src/niamoto/gui/ui/src/features/dashboard/components/KeyStats.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/KeyStats.tsx
@@ -111,8 +111,10 @@ export function KeyStats({
           value={htmlPageCount}
           sub={
             totalSizeMb != null
-              ? `pages HTML · ${totalSizeMb} Mo`
-              : "pages HTML"
+              ? t("pipeline.stats.pages_html_size", "pages HTML · {{size}} Mo", {
+                  size: totalSizeMb,
+                })
+              : t("pipeline.stats.pages_html", "pages HTML")
           }
         />
       )}

--- a/src/niamoto/gui/ui/src/features/dashboard/components/PipelineBar.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/PipelineBar.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next"
+import type { TFunction } from "i18next"
 import { formatDistanceToNow } from "date-fns"
 import { enUS, fr } from "date-fns/locale"
 import {
@@ -98,62 +99,87 @@ interface PipelineBarProps {
   publication: StageStatus | undefined
 }
 
-function entitySummaryLine(stage: StageStatus | undefined): string | null {
+function entitySummaryLine(
+  stage: StageStatus | undefined,
+  t: TFunction,
+  language: string,
+): string | null {
   if (!stage?.summary) return null
   const s = stage.summary
+  const locale = language === "fr" ? "fr-FR" : "en-US"
 
-  // Data stage
+  // Data stage : total rows across all entities
   if (s.entities) {
     const total = s.entities.reduce((acc, e) => acc + e.row_count, 0)
     if (total === 0) return null
-    return total.toLocaleString() + " lignes"
+    const formatted = total.toLocaleString(locale)
+    return t("pipeline.summary.rows", "{{count}} lignes", {
+      count: total,
+      formattedCount: formatted,
+      defaultValue_one: "{{formattedCount}} ligne",
+      defaultValue_other: "{{formattedCount}} lignes",
+    })
   }
 
-  // Groups stage
+  // Groups stage : number of configured groups
   if (s.groups) {
     const count = s.groups.length
     if (count === 0) return null
-    return count + " groupe" + (count > 1 ? "s" : "")
+    return t("pipeline.summary.groups", {
+      count,
+      defaultValue_one: "{{count}} groupe",
+      defaultValue_other: "{{count}} groupes",
+    })
   }
 
+  // Site configured pages
   if (s.page_count != null) {
-    return s.page_count + " page" + (s.page_count > 1 ? "s" : "")
+    return t("pipeline.summary.pages", {
+      count: s.page_count,
+      defaultValue_one: "{{count}} page",
+      defaultValue_other: "{{count}} pages",
+    })
   }
 
+  // Published HTML pages
   if (s.html_page_count != null) {
-    return s.html_page_count + " page" + (s.html_page_count > 1 ? "s" : "")
+    return t("pipeline.summary.pages", {
+      count: s.html_page_count,
+      defaultValue_one: "{{count}} page",
+      defaultValue_other: "{{count}} pages",
+    })
   }
 
   return null
 }
 
 export function PipelineBar({ data, groups, site, publication }: PipelineBarProps) {
-  const { t } = useTranslation("common")
+  const { t, i18n } = useTranslation("common")
 
   return (
     <div className="flex items-center gap-2">
       <PipelineStage
         label={t("sidebar.nav.data", "Import")}
         stage={data}
-        entityLine={entitySummaryLine(data)}
+        entityLine={entitySummaryLine(data, t, i18n.language)}
       />
       <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" />
       <PipelineStage
         label={t("sidebar.nav.collections", "Transform")}
         stage={groups}
-        entityLine={entitySummaryLine(groups)}
+        entityLine={entitySummaryLine(groups, t, i18n.language)}
       />
       <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" />
       <PipelineStage
         label={t("sidebar.nav.site", "Site")}
         stage={site}
-        entityLine={entitySummaryLine(site)}
+        entityLine={entitySummaryLine(site, t, i18n.language)}
       />
       <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" />
       <PipelineStage
         label={t("sidebar.nav.publish", "Export")}
         stage={publication}
-        entityLine={entitySummaryLine(publication)}
+        entityLine={entitySummaryLine(publication, t, i18n.language)}
       />
     </div>
   )

--- a/src/niamoto/gui/ui/src/features/dashboard/components/PipelineBar.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/PipelineBar.tsx
@@ -94,6 +94,7 @@ function PipelineStage({ label, stage, entityLine }: PipelineStageProps) {
 interface PipelineBarProps {
   data: StageStatus | undefined
   groups: StageStatus | undefined
+  site: StageStatus | undefined
   publication: StageStatus | undefined
 }
 
@@ -115,7 +116,10 @@ function entitySummaryLine(stage: StageStatus | undefined): string | null {
     return count + " groupe" + (count > 1 ? "s" : "")
   }
 
-  // Publication stage
+  if (s.page_count != null) {
+    return s.page_count + " page" + (s.page_count > 1 ? "s" : "")
+  }
+
   if (s.html_page_count != null) {
     return s.html_page_count + " page" + (s.html_page_count > 1 ? "s" : "")
   }
@@ -123,7 +127,7 @@ function entitySummaryLine(stage: StageStatus | undefined): string | null {
   return null
 }
 
-export function PipelineBar({ data, groups, publication }: PipelineBarProps) {
+export function PipelineBar({ data, groups, site, publication }: PipelineBarProps) {
   const { t } = useTranslation("common")
 
   return (
@@ -138,6 +142,12 @@ export function PipelineBar({ data, groups, publication }: PipelineBarProps) {
         label={t("sidebar.nav.collections", "Transform")}
         stage={groups}
         entityLine={entitySummaryLine(groups)}
+      />
+      <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" />
+      <PipelineStage
+        label={t("sidebar.nav.site", "Site")}
+        stage={site}
+        entityLine={entitySummaryLine(site)}
       />
       <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" />
       <PipelineStage

--- a/src/niamoto/gui/ui/src/features/dashboard/components/PipelineBar.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/PipelineBar.tsx
@@ -32,16 +32,16 @@ function statusConfig(status: FreshnessStatus) {
         icon: <AlertTriangle className="h-4 w-4 text-amber-500" />,
         dot: "bg-amber-500",
         text: "text-amber-600 dark:text-amber-400",
-        ring: "ring-amber-500/30",
-        bg: "bg-amber-50 dark:bg-amber-950/30",
+        ring: "ring-border/60",
+        bg: "bg-muted/30",
       }
     case "running":
       return {
         icon: <Loader2 className="h-4 w-4 animate-spin text-blue-500" />,
         dot: "bg-blue-500 animate-pulse",
         text: "text-blue-600 dark:text-blue-400",
-        ring: "ring-blue-500/30",
-        bg: "bg-blue-50 dark:bg-blue-950/30",
+        ring: "ring-border/60",
+        bg: "bg-muted/30",
       }
     default:
       return {

--- a/src/niamoto/gui/ui/src/features/dashboard/components/PipelineBar.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/PipelineBar.tsx
@@ -1,0 +1,150 @@
+import { useTranslation } from "react-i18next"
+import { formatDistanceToNow } from "date-fns"
+import { enUS, fr } from "date-fns/locale"
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronRight,
+  Circle,
+  Loader2,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { FreshnessStatus, StageStatus } from "@/hooks/usePipelineStatus"
+
+interface PipelineStageProps {
+  label: string
+  stage: StageStatus | undefined
+  entityLine: string | null
+}
+
+function statusConfig(status: FreshnessStatus) {
+  switch (status) {
+    case "fresh":
+      return {
+        icon: <CheckCircle2 className="h-4 w-4 text-green-500" />,
+        dot: "bg-green-500",
+        text: "text-green-600 dark:text-green-400",
+        ring: "ring-green-500/30",
+        bg: "bg-green-50 dark:bg-green-950/30",
+      }
+    case "stale":
+      return {
+        icon: <AlertTriangle className="h-4 w-4 text-amber-500" />,
+        dot: "bg-amber-500",
+        text: "text-amber-600 dark:text-amber-400",
+        ring: "ring-amber-500/30",
+        bg: "bg-amber-50 dark:bg-amber-950/30",
+      }
+    case "running":
+      return {
+        icon: <Loader2 className="h-4 w-4 animate-spin text-blue-500" />,
+        dot: "bg-blue-500 animate-pulse",
+        text: "text-blue-600 dark:text-blue-400",
+        ring: "ring-blue-500/30",
+        bg: "bg-blue-50 dark:bg-blue-950/30",
+      }
+    default:
+      return {
+        icon: <Circle className="h-4 w-4 text-muted-foreground/50" />,
+        dot: "bg-muted-foreground/30",
+        text: "text-muted-foreground",
+        ring: "ring-muted/30",
+        bg: "bg-muted/20",
+      }
+  }
+}
+
+function PipelineStage({ label, stage, entityLine }: PipelineStageProps) {
+  const { i18n } = useTranslation()
+  const dateLocale = i18n.language === "fr" ? fr : enUS
+  const status = stage?.status ?? "never_run"
+  const cfg = statusConfig(status)
+
+  const timeAgo = stage?.last_run_at
+    ? formatDistanceToNow(new Date(stage.last_run_at), {
+        addSuffix: true,
+        locale: dateLocale,
+      })
+    : null
+
+  return (
+    <div
+      className={cn(
+        "flex flex-1 flex-col gap-1.5 rounded-xl px-4 py-3 ring-1",
+        cfg.bg,
+        cfg.ring,
+      )}
+    >
+      <div className="flex items-center gap-2">
+        {cfg.icon}
+        <span className="text-sm font-semibold">{label}</span>
+      </div>
+      {entityLine && (
+        <p className={cn("text-xs font-medium", cfg.text)}>{entityLine}</p>
+      )}
+      {timeAgo ? (
+        <p className="text-xs text-muted-foreground">{timeAgo}</p>
+      ) : (
+        <p className="text-xs text-muted-foreground/60">—</p>
+      )}
+    </div>
+  )
+}
+
+interface PipelineBarProps {
+  data: StageStatus | undefined
+  groups: StageStatus | undefined
+  publication: StageStatus | undefined
+}
+
+function entitySummaryLine(stage: StageStatus | undefined): string | null {
+  if (!stage?.summary) return null
+  const s = stage.summary
+
+  // Data stage
+  if (s.entities) {
+    const total = s.entities.reduce((acc, e) => acc + e.row_count, 0)
+    if (total === 0) return null
+    return total.toLocaleString() + " lignes"
+  }
+
+  // Groups stage
+  if (s.groups) {
+    const count = s.groups.length
+    if (count === 0) return null
+    return count + " groupe" + (count > 1 ? "s" : "")
+  }
+
+  // Publication stage
+  if (s.html_page_count != null) {
+    return s.html_page_count + " page" + (s.html_page_count > 1 ? "s" : "")
+  }
+
+  return null
+}
+
+export function PipelineBar({ data, groups, publication }: PipelineBarProps) {
+  const { t } = useTranslation("common")
+
+  return (
+    <div className="flex items-center gap-2">
+      <PipelineStage
+        label={t("sidebar.nav.data", "Import")}
+        stage={data}
+        entityLine={entitySummaryLine(data)}
+      />
+      <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" />
+      <PipelineStage
+        label={t("sidebar.nav.collections", "Transform")}
+        stage={groups}
+        entityLine={entitySummaryLine(groups)}
+      />
+      <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" />
+      <PipelineStage
+        label={t("sidebar.nav.publish", "Export")}
+        stage={publication}
+        entityLine={entitySummaryLine(publication)}
+      />
+    </div>
+  )
+}

--- a/src/niamoto/gui/ui/src/features/dashboard/components/PipelineBar.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/PipelineBar.tsx
@@ -23,9 +23,9 @@ function statusConfig(status: FreshnessStatus) {
       return {
         icon: <CheckCircle2 className="h-4 w-4 text-green-500" />,
         dot: "bg-green-500",
-        text: "text-green-600 dark:text-green-400",
-        ring: "ring-green-500/30",
-        bg: "bg-green-50 dark:bg-green-950/30",
+        text: "text-green-700 dark:text-green-400",
+        ring: "ring-border/60",
+        bg: "bg-muted/30",
       }
     case "stale":
       return {

--- a/src/niamoto/gui/ui/src/features/dashboard/components/QuickActions.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/QuickActions.tsx
@@ -27,6 +27,7 @@ function QuickAction({
       variant={variant === "primary" ? "default" : "outline"}
       className={cn(
         "flex h-auto flex-col items-start gap-0.5 px-3 py-2.5 text-left",
+        variant !== "primary" && "hover:bg-muted hover:text-foreground",
         disabled && "pointer-events-none opacity-40",
       )}
       onClick={onClick}

--- a/src/niamoto/gui/ui/src/features/dashboard/components/QuickActions.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/QuickActions.tsx
@@ -1,0 +1,127 @@
+import { useNavigate } from "react-router-dom"
+import { useTranslation } from "react-i18next"
+import { Database, Eye, Layers, RefreshCw, Send } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type { FreshnessStatus } from "@/hooks/usePipelineStatus"
+
+interface QuickActionProps {
+  icon: React.ReactNode
+  label: string
+  description: string
+  onClick: () => void
+  disabled?: boolean
+  variant?: "default" | "outline" | "primary"
+}
+
+function QuickAction({
+  icon,
+  label,
+  description,
+  onClick,
+  disabled = false,
+  variant = "outline",
+}: QuickActionProps) {
+  return (
+    <Button
+      variant={variant === "primary" ? "default" : "outline"}
+      className={cn(
+        "flex h-auto flex-col items-start gap-0.5 px-3 py-2.5 text-left",
+        disabled && "pointer-events-none opacity-40",
+      )}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <span className="flex items-center gap-1.5 text-xs font-semibold">
+        {icon}
+        {label}
+      </span>
+      <span className="text-[11px] font-normal text-muted-foreground">
+        {description}
+      </span>
+    </Button>
+  )
+}
+
+interface QuickActionsProps {
+  dataStatus: FreshnessStatus
+  groupsStatus: FreshnessStatus
+  siteStatus: FreshnessStatus
+  publicationStatus: FreshnessStatus
+  isRunning: boolean
+}
+
+export function QuickActions({
+  dataStatus,
+  groupsStatus,
+  siteStatus,
+  publicationStatus,
+  isRunning,
+}: QuickActionsProps) {
+  const { t } = useTranslation("common")
+  const navigate = useNavigate()
+
+  const hasData = dataStatus === "fresh" || dataStatus === "stale"
+  const groupsReady = groupsStatus === "fresh"
+  const siteConfigured = siteStatus === "fresh"
+
+  // Transform : dispo si on a des données et que les groupes ne sont pas en train de tourner
+  const canTransform = hasData && !isRunning
+  // Rebuild : dispo si groupes à jour et site configuré
+  const canRebuild = groupsReady && siteConfigured && !isRunning
+  // Publish : dispo si export stale ou jamais publié
+  const canPublish =
+    groupsReady &&
+    (publicationStatus === "stale" || publicationStatus === "never_run") &&
+    !isRunning
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <QuickAction
+        icon={<Database className="h-3.5 w-3.5" />}
+        label={t("pipeline.action_import", "Import")}
+        description={t("pipeline.action_import_desc", "Charger les données sources")}
+        onClick={() => navigate("/sources/import")}
+        disabled={isRunning}
+        variant={dataStatus === "never_run" ? "primary" : "outline"}
+      />
+      <QuickAction
+        icon={<Layers className="h-3.5 w-3.5" />}
+        label={t("pipeline.action_recalculate", "Recalculer")}
+        description={t(
+          "pipeline.action_recalculate_desc",
+          "Calculer les statistiques",
+        )}
+        onClick={() => navigate("/groups")}
+        disabled={!canTransform}
+        variant={
+          groupsStatus === "stale" || groupsStatus === "never_run"
+            ? "primary"
+            : "outline"
+        }
+      />
+      <QuickAction
+        icon={<RefreshCw className="h-3.5 w-3.5" />}
+        label={t("pipeline.action_rebuild", "Reconstruire")}
+        description={t("pipeline.action_rebuild_desc", "Générer le site HTML")}
+        onClick={() => navigate("/publish")}
+        disabled={!canRebuild}
+        variant={publicationStatus === "stale" ? "primary" : "outline"}
+      />
+      <QuickAction
+        icon={<Eye className="h-3.5 w-3.5" />}
+        label={t("tools.preview", "Prévisualiser")}
+        description={t("pipeline.action_preview_desc", "Voir le rendu des widgets")}
+        onClick={() => navigate("/tools/preview")}
+        disabled={!hasData}
+      />
+      <QuickAction
+        icon={<Send className="h-3.5 w-3.5" />}
+        label={t("pipeline.action_publish", "Publier")}
+        description={t("pipeline.action_publish_desc", "Déployer sur le serveur")}
+        onClick={() => navigate("/publish?panel=destinations")}
+        disabled={!canPublish}
+      />
+    </div>
+  )
+}

--- a/src/niamoto/gui/ui/src/features/dashboard/components/QuickActions.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/QuickActions.tsx
@@ -11,7 +11,7 @@ interface QuickActionProps {
   description: string
   onClick: () => void
   disabled?: boolean
-  variant?: "default" | "outline" | "primary"
+  primary?: boolean
 }
 
 function QuickAction({
@@ -20,14 +20,14 @@ function QuickAction({
   description,
   onClick,
   disabled = false,
-  variant = "outline",
+  primary = false,
 }: QuickActionProps) {
   return (
     <Button
-      variant={variant === "primary" ? "default" : "outline"}
+      variant={primary ? "default" : "outline"}
       className={cn(
         "flex h-auto flex-col items-start gap-0.5 px-3 py-2.5 text-left",
-        variant !== "primary" && "hover:bg-muted hover:text-foreground",
+        !primary && "hover:bg-muted hover:text-foreground",
         disabled && "pointer-events-none opacity-40",
       )}
       onClick={onClick}
@@ -37,7 +37,12 @@ function QuickAction({
         {icon}
         {label}
       </span>
-      <span className="text-[11px] font-normal text-muted-foreground">
+      <span
+        className={cn(
+          "text-[11px] font-normal",
+          primary ? "text-primary-foreground/60" : "text-muted-foreground",
+        )}
+      >
         {description}
       </span>
     </Button>
@@ -50,6 +55,8 @@ interface QuickActionsProps {
   siteStatus: FreshnessStatus
   publicationStatus: FreshnessStatus
   isRunning: boolean
+  /** True si la DB contient des entités (indépendamment du job store GUI). */
+  hasEntities: boolean
 }
 
 export function QuickActions({
@@ -58,23 +65,37 @@ export function QuickActions({
   siteStatus,
   publicationStatus,
   isRunning,
+  hasEntities,
 }: QuickActionsProps) {
   const { t } = useTranslation("common")
   const navigate = useNavigate()
 
-  const hasData = dataStatus === "fresh" || dataStatus === "stale"
+  // hasData : données présentes, qu'elles viennent du GUI ou du CLI
+  const hasData =
+    hasEntities ||
+    dataStatus === "fresh" ||
+    dataStatus === "stale"
+
   const groupsReady = groupsStatus === "fresh"
   const siteConfigured = siteStatus === "fresh"
 
-  // Transform : dispo si on a des données et que les groupes ne sont pas en train de tourner
   const canTransform = hasData && !isRunning
-  // Rebuild : dispo si groupes à jour et site configuré
   const canRebuild = groupsReady && siteConfigured && !isRunning
-  // Publish : dispo si export stale ou jamais publié
   const canPublish =
     groupsReady &&
     (publicationStatus === "stale" || publicationStatus === "never_run") &&
     !isRunning
+
+  // Import : jamais primary (action de maintenance, pas un CTA principal)
+  // Recalculate : primary si groupes stale/never_run ET données présentes
+  const recalcPrimary =
+    hasData &&
+    !isRunning &&
+    (groupsStatus === "stale" || groupsStatus === "never_run")
+
+  // Rebuild : primary si publication stale
+  const rebuildPrimary =
+    canRebuild && publicationStatus === "stale"
 
   return (
     <div className="flex flex-wrap gap-2">
@@ -84,22 +105,14 @@ export function QuickActions({
         description={t("pipeline.action_import_desc", "Charger les données sources")}
         onClick={() => navigate("/sources/import")}
         disabled={isRunning}
-        variant={dataStatus === "never_run" ? "primary" : "outline"}
       />
       <QuickAction
         icon={<Layers className="h-3.5 w-3.5" />}
         label={t("pipeline.action_recalculate", "Recalculer")}
-        description={t(
-          "pipeline.action_recalculate_desc",
-          "Calculer les statistiques",
-        )}
+        description={t("pipeline.action_recalculate_desc", "Calculer les statistiques")}
         onClick={() => navigate("/groups")}
         disabled={!canTransform}
-        variant={
-          groupsStatus === "stale" || groupsStatus === "never_run"
-            ? "primary"
-            : "outline"
-        }
+        primary={recalcPrimary}
       />
       <QuickAction
         icon={<RefreshCw className="h-3.5 w-3.5" />}
@@ -107,7 +120,7 @@ export function QuickActions({
         description={t("pipeline.action_rebuild_desc", "Générer le site HTML")}
         onClick={() => navigate("/publish")}
         disabled={!canRebuild}
-        variant={publicationStatus === "stale" ? "primary" : "outline"}
+        primary={rebuildPrimary}
       />
       <QuickAction
         icon={<Eye className="h-3.5 w-3.5" />}

--- a/src/niamoto/gui/ui/src/features/dashboard/components/QuickActions.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/QuickActions.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { Database, Eye, Layers, RefreshCw, Send } from "lucide-react"
+import { Database, Eye, Layers, Map, RefreshCw, Send } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import type { FreshnessStatus } from "@/hooks/usePipelineStatus"
@@ -81,21 +81,16 @@ export function QuickActions({
 
   const canTransform = hasData && !isRunning
   const canRebuild = groupsReady && siteConfigured && !isRunning
-  const canPublish =
-    groupsReady &&
-    (publicationStatus === "stale" || publicationStatus === "never_run") &&
-    !isRunning
+  const canPublish = siteConfigured && publicationStatus === "fresh" && !isRunning
 
-  // Import : jamais primary (action de maintenance, pas un CTA principal)
-  // Recalculate : primary si groupes stale/never_run ET données présentes
   const recalcPrimary =
     hasData &&
     !isRunning &&
     (groupsStatus === "stale" || groupsStatus === "never_run")
 
-  // Rebuild : primary si publication stale
   const rebuildPrimary =
-    canRebuild && publicationStatus === "stale"
+    canRebuild &&
+    (publicationStatus === "stale" || publicationStatus === "never_run")
 
   return (
     <div className="flex flex-wrap gap-2">
@@ -113,6 +108,13 @@ export function QuickActions({
         onClick={() => navigate("/groups")}
         disabled={!canTransform}
         primary={recalcPrimary}
+      />
+      <QuickAction
+        icon={<Map className="h-3.5 w-3.5" />}
+        label={t("pipeline.action_configure", "Configurer")}
+        description={t("pipeline.action_configure_desc", "Définir les pages du site")}
+        onClick={() => navigate("/site/pages")}
+        disabled={isRunning}
       />
       <QuickAction
         icon={<RefreshCw className="h-3.5 w-3.5" />}

--- a/src/niamoto/gui/ui/src/features/dashboard/components/dashboardRedesign.test.tsx
+++ b/src/niamoto/gui/ui/src/features/dashboard/components/dashboardRedesign.test.tsx
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import { DashboardView } from "./DashboardView"
+import { QuickActions } from "./QuickActions"
+import { ActivityFeed } from "./ActivityFeed"
+import type { PipelineStatus } from "@/hooks/usePipelineStatus"
+
+const pipelineStatusState = vi.hoisted(() => ({
+  value: {
+    data: null,
+    isLoading: false,
+    isFetching: false,
+  },
+}))
+
+const pipelineHistoryState = vi.hoisted(() => ({
+  value: {
+    data: [],
+  },
+}))
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>(
+    "react-i18next",
+  )
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (
+        key: string,
+        defaultValue?: string | Record<string, unknown>,
+        options?: Record<string, unknown>,
+      ) => {
+        if (typeof defaultValue === "string") {
+          return defaultValue.replace(/\{\{(\w+)\}\}/g, (_match, token: string) =>
+            String(options?.[token] ?? ""),
+          )
+        }
+        return key
+      },
+      i18n: {
+        language: "fr",
+        resolvedLanguage: "fr",
+      },
+    }),
+  }
+})
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock("date-fns", () => ({
+  formatDistanceToNow: () => "il y a un instant",
+}))
+
+vi.mock("@/hooks/usePipelineStatus", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/usePipelineStatus")>(
+    "@/hooks/usePipelineStatus",
+  )
+  return {
+    ...actual,
+    usePipelineStatus: () => pipelineStatusState.value,
+  }
+})
+
+vi.mock("@/hooks/usePipelineHistory", () => ({
+  usePipelineHistory: () => pipelineHistoryState.value,
+}))
+
+function buildPipelineStatus(
+  overrides: Partial<PipelineStatus> = {},
+): PipelineStatus {
+  return {
+    data: {
+      status: "fresh",
+      last_run_at: "2026-04-19T10:00:00",
+      items: [],
+      summary: {
+        entities: [{ name: "taxons", row_count: 12 }],
+      },
+      last_job_duration_s: 4,
+    },
+    groups: {
+      status: "fresh",
+      last_run_at: "2026-04-19T10:05:00",
+      items: [],
+      summary: {
+        groups: [{ name: "plots", entity_count: 3 }],
+      },
+      last_job_duration_s: 9,
+    },
+    site: {
+      status: "fresh",
+      last_run_at: null,
+      items: [],
+      summary: {
+        page_count: 8,
+      },
+      last_job_duration_s: null,
+    },
+    publication: {
+      status: "fresh",
+      last_run_at: "2026-04-19T10:10:00",
+      items: [],
+      summary: {
+        html_page_count: 8,
+        total_size_mb: 2.4,
+      },
+      last_job_duration_s: 7,
+    },
+    running_job: null,
+    ...overrides,
+  }
+}
+
+describe("dashboard redesign regressions", () => {
+  it("keeps the dashboard in pending state until the first build exists", () => {
+    pipelineStatusState.value = {
+      data: buildPipelineStatus({
+        publication: {
+          status: "never_run",
+          last_run_at: null,
+          items: [],
+          summary: {
+            html_page_count: 0,
+            total_size_mb: 0,
+          },
+          last_job_duration_s: null,
+        },
+      }),
+      isLoading: false,
+      isFetching: false,
+    }
+    pipelineHistoryState.value = { data: [] }
+
+    const html = renderToStaticMarkup(<DashboardView />)
+
+    expect(html).toContain("Étapes initiales en attente")
+    expect(html).not.toContain("Tout est à jour")
+  })
+
+  it("surfaces site configuration and keeps publish disabled until a build exists", () => {
+    const html = renderToStaticMarkup(
+      <QuickActions
+        dataStatus="fresh"
+        groupsStatus="fresh"
+        siteStatus="unconfigured"
+        publicationStatus="never_run"
+        isRunning={false}
+        hasEntities
+      />,
+    )
+
+    expect(html).toContain("Configurer")
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>[\s\S]*Publier/)
+  })
+
+  it("renders the recent job history instead of synthesizing only one row per stage", () => {
+    pipelineHistoryState.value = {
+      data: [
+        {
+          id: "job-failed-transform",
+          type: "transform",
+          status: "failed",
+          started_at: "2026-04-19T10:08:00",
+          completed_at: "2026-04-19T10:09:00",
+          message: "Échec sur la collection plots",
+        },
+        {
+          id: "job-completed-transform",
+          type: "transform",
+          status: "completed",
+          started_at: "2026-04-19T10:05:00",
+          completed_at: "2026-04-19T10:06:30",
+          message: "Recalcul terminé",
+        },
+      ],
+    }
+
+    const html = renderToStaticMarkup(<ActivityFeed />)
+
+    expect(html).toContain("Échec sur la collection plots")
+    expect(html).toContain("Recalcul terminé")
+  })
+})

--- a/src/niamoto/gui/ui/src/hooks/usePipelineHistory.ts
+++ b/src/niamoto/gui/ui/src/hooks/usePipelineHistory.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiClient } from '@/shared/lib/api/client'
+
+export interface JobHistoryEntry {
+  id: string
+  type: 'import' | 'transform' | 'export' | string
+  status: 'completed' | 'failed' | 'cancelled' | string
+  group_by?: string | null
+  group_bys?: string[] | null
+  started_at: string
+  completed_at?: string | null
+  progress?: number
+  message?: string
+}
+
+export function usePipelineHistory(limit = 10) {
+  return useQuery<JobHistoryEntry[]>({
+    queryKey: ['pipeline-history', limit],
+    queryFn: async () => {
+      const response = await apiClient.get('/pipeline/history', { params: { limit } })
+      const data = response.data
+      return Array.isArray(data) ? data : []
+    },
+    staleTime: 30_000,
+    refetchOnMount: 'always',
+    retry: 1,
+  })
+}

--- a/tests/gui/api/routers/test_pipeline.py
+++ b/tests/gui/api/routers/test_pipeline.py
@@ -2,6 +2,7 @@ import asyncio
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 import niamoto.gui.api.routers.pipeline as pipeline_router
@@ -196,3 +197,108 @@ def test_pipeline_marks_batch_transform_groups_as_fresh(tmp_path: Path, monkeypa
 
     assert plots_status.status == "fresh"
     assert taxons_status.status == "fresh"
+
+
+# ---------------------------------------------------------------------------
+# /api/pipeline/history endpoint
+# ---------------------------------------------------------------------------
+
+
+def _build_history_app(history_entries: list[dict], monkeypatch) -> FastAPI:
+    """Build a minimal FastAPI app with a stub job_store for history tests."""
+
+    class DummyStore:
+        def __init__(self, entries: list[dict]):
+            self._entries = entries
+            self.last_limit: int | None = None
+
+        def get_history(self, limit: int = 20) -> list[dict]:
+            self.last_limit = limit
+            return self._entries[:limit]
+
+    store = DummyStore(history_entries)
+    app = FastAPI()
+    app.state.job_store = store
+    app.include_router(pipeline_router.router, prefix="/api/pipeline")
+    monkeypatch.setattr(
+        pipeline_router, "resolve_job_store", lambda app: app.state.job_store
+    )
+    return app
+
+
+def test_pipeline_history_returns_entries(monkeypatch):
+    entries = [
+        {"id": "a", "type": "import", "status": "completed"},
+        {"id": "b", "type": "transform", "status": "completed"},
+    ]
+    app = _build_history_app(entries, monkeypatch)
+    client = TestClient(app)
+
+    response = client.get("/api/pipeline/history?limit=5")
+
+    assert response.status_code == 200
+    assert response.json() == entries
+    assert app.state.job_store.last_limit == 5
+
+
+def test_pipeline_history_default_limit(monkeypatch):
+    app = _build_history_app([], monkeypatch)
+    client = TestClient(app)
+
+    response = client.get("/api/pipeline/history")
+
+    assert response.status_code == 200
+    assert app.state.job_store.last_limit == 10
+
+
+def test_pipeline_history_rejects_zero_limit(monkeypatch):
+    app = _build_history_app([{"id": "a"}], monkeypatch)
+    client = TestClient(app)
+
+    response = client.get("/api/pipeline/history?limit=0")
+
+    assert response.status_code == 422
+
+
+def test_pipeline_history_rejects_negative_limit(monkeypatch):
+    app = _build_history_app([{"id": "a"}], monkeypatch)
+    client = TestClient(app)
+
+    response = client.get("/api/pipeline/history?limit=-1")
+
+    assert response.status_code == 422
+
+
+def test_pipeline_history_rejects_limit_above_max(monkeypatch):
+    app = _build_history_app([{"id": "a"}], monkeypatch)
+    client = TestClient(app)
+
+    response = client.get("/api/pipeline/history?limit=101")
+
+    assert response.status_code == 422
+
+
+def test_pipeline_history_accepts_boundary_values(monkeypatch):
+    app = _build_history_app([], monkeypatch)
+    client = TestClient(app)
+
+    for boundary in (1, 100):
+        response = client.get(f"/api/pipeline/history?limit={boundary}")
+        assert response.status_code == 200
+        assert app.state.job_store.last_limit == boundary
+
+
+def test_pipeline_history_returns_empty_when_store_resolution_fails(monkeypatch):
+    app = FastAPI()
+    app.include_router(pipeline_router.router, prefix="/api/pipeline")
+
+    def failing_resolve(_app):
+        raise RuntimeError("no project loaded")
+
+    monkeypatch.setattr(pipeline_router, "resolve_job_store", failing_resolve)
+    client = TestClient(app)
+
+    response = client.get("/api/pipeline/history")
+
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
## Summary
Rework the dashboard into a compact pipeline overview with direct next actions and clearer status cues.

This replaces the old stage-card layout with a flow that surfaces what needs attention first while keeping site configuration and publication readiness visible.

## What Changed
- replace the previous dashboard cards with a pipeline bar, contextual header state, key stats, and quick actions
- keep the site step visible in the dashboard flow and tighten action gating so publishing only unlocks after a fresh build
- expose recent pipeline history from the API and render recent jobs, including failures and job messages, in the activity feed
- add regression coverage for the dashboard status cues and quick-action availability

## Testing
- `pnpm test src/features/dashboard/components/dashboardRedesign.test.tsx`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an activity feed to the dashboard displaying recent pipeline job history with timestamps, status, and completion details.
  * Redesigned dashboard layout with organized sections for key statistics, pipeline progress tracking, and quick action shortcuts.
  * Enhanced pipeline status visualization with real-time progress indicators and improved state management for running jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->