### PR TITLE
Marketing site sync: plugin manifest + auto-redeploy

### DIFF
--- a/.github/workflows/marketing-sync.yml
+++ b/.github/workflows/marketing-sync.yml
@@ -1,0 +1,53 @@
+name: Marketing site sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/niamoto/core/plugins/**"
+      - "docs/0*/README.md"
+      - "ROADMAP.md"
+      - "CHANGELOG.md"
+      - "pyproject.toml"
+      - ".marketing/**"
+      - "scripts/generate-plugin-manifest.py"
+      - ".github/workflows/marketing-sync.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Regenerate plugin manifest
+        run: python scripts/generate-plugin-manifest.py
+
+      - name: Commit manifest if changed
+        run: |
+          if ! git diff --quiet -- .marketing/plugins.json; then
+            git config user.name "niamoto-bot"
+            git config user.email "bot@niamoto.org"
+            git add .marketing/plugins.json
+            git commit -m "chore: regenerate .marketing/plugins.json [skip ci]"
+            git push
+          else
+            echo "Plugin manifest unchanged — skipping commit."
+          fi
+
+      - name: Trigger niamoto-site rebuild
+        run: |
+          curl --fail -X GET "$COOLIFY_WEBHOOK" \
+            -H "Authorization: Bearer $COOLIFY_TOKEN"
+        env:
+          COOLIFY_WEBHOOK: ${{ secrets.COOLIFY_WEBHOOK }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}

--- a/.marketing/plugins.json
+++ b/.marketing/plugins.json
@@ -1,0 +1,404 @@
+[
+  {
+    "name": "cloudflare",
+    "type": "deployer",
+    "body": "Deploy static assets to Cloudflare Workers.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "github",
+    "type": "deployer",
+    "body": "Deploy static sites to GitHub Pages.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "netlify",
+    "type": "deployer",
+    "body": "Deploy static sites to Netlify via ZIP upload.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "render",
+    "type": "deployer",
+    "body": "Deploy to Render via Deploy Hook or API.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "ssh",
+    "type": "deployer",
+    "body": "Deploy static sites via rsync over SSH.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "vercel",
+    "type": "deployer",
+    "body": "Deploy static sites to Vercel via the Deployments API.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "dwc_archive_exporter",
+    "type": "exporter",
+    "body": "Generates standard Darwin Core Archive files.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "html_page_exporter",
+    "type": "exporter",
+    "body": "Generates a static HTML website based on the export configuration.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "index_generator",
+    "type": "exporter",
+    "body": "Plugin for generating configurable index pages for groups.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "json_api_exporter",
+    "type": "exporter",
+    "body": "Generates static JSON API files based on the export configuration.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "adjacency_list",
+    "type": "loader",
+    "body": "Loader for adjacency list hierarchies.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "api_elevation_enricher",
+    "type": "loader",
+    "body": "Enrich a point or geometry with elevation data.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "api_spatial_enricher",
+    "type": "loader",
+    "body": "Enrich a point or geometry with GeoNames administrative context.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "api_taxonomy_enricher",
+    "type": "loader",
+    "body": "Plugin for enriching taxonomy data with information from external APIs",
+    "version": "0.15.5"
+  },
+  {
+    "name": "direct_reference",
+    "type": "loader",
+    "body": "Loader using direct references between tables",
+    "version": "0.15.5"
+  },
+  {
+    "name": "join_table",
+    "type": "loader",
+    "body": "Loader using join tables",
+    "version": "0.15.5"
+  },
+  {
+    "name": "nested_set",
+    "type": "loader",
+    "body": "Loader for nested set hierarchies",
+    "version": "0.15.5"
+  },
+  {
+    "name": "spatial_containment",
+    "type": "loader",
+    "body": "Loader using spatial queries",
+    "version": "0.15.5"
+  },
+  {
+    "name": "stats_loader",
+    "type": "loader",
+    "body": "Plugin for loading statistics from various sources.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "binary_counter",
+    "type": "transformer",
+    "body": "Plugin for counting binary values",
+    "version": "0.15.5"
+  },
+  {
+    "name": "binned_distribution",
+    "type": "transformer",
+    "body": "Plugin for creating binned distributions",
+    "version": "0.15.5"
+  },
+  {
+    "name": "boolean_comparison",
+    "type": "transformer",
+    "body": "Plugin de comparaison de champs booléens.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "categorical_distribution",
+    "type": "transformer",
+    "body": "Plugin for creating categorical distributions",
+    "version": "0.15.5"
+  },
+  {
+    "name": "class_object_binary_aggregator",
+    "type": "transformer",
+    "body": "Plugin for handling binary/ternary class distributions",
+    "version": "0.15.5"
+  },
+  {
+    "name": "class_object_categories_extractor",
+    "type": "transformer",
+    "body": "Plugin for extracting ordered categorical values",
+    "version": "0.15.5"
+  },
+  {
+    "name": "class_object_categories_mapper",
+    "type": "transformer",
+    "body": "Plugin for mapping class object data into categories",
+    "version": "0.15.5"
+  },
+  {
+    "name": "class_object_field_aggregator",
+    "type": "transformer",
+    "body": "Plugin for aggregating fields from class objects",
+    "version": "0.15.5"
+  },
+  {
+    "name": "class_object_series_by_axis_extractor",
+    "type": "transformer",
+    "body": "Plugin for extracting series by axis from class objects",
+    "version": "0.15.5"
+  },
+  {
+    "name": "class_object_series_extractor",
+    "type": "transformer",
+    "body": "Plugin for extracting series from class_object data",
+    "version": "0.15.5"
+  },
+  {
+    "name": "class_object_series_matrix_extractor",
+    "type": "transformer",
+    "body": "Plugin for extracting and transforming series into a matrix format",
+    "version": "0.15.5"
+  },
+  {
+    "name": "class_object_series_ratio_aggregator",
+    "type": "transformer",
+    "body": "Plugin for calculating ratios between series distributions",
+    "version": "0.15.5"
+  },
+  {
+    "name": "custom_calculator",
+    "type": "transformer",
+    "body": "Plugin for performing custom calculations on data from other transformers.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "custom_formatter",
+    "type": "transformer",
+    "body": "Plugin that formats data according to a specified template.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "database_aggregator",
+    "type": "transformer",
+    "body": "Execute SQL queries for cross-cutting data aggregation.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "direct_attribute",
+    "type": "transformer",
+    "body": "Plugin for getting a direct attribute",
+    "version": "0.15.5"
+  },
+  {
+    "name": "elevation_profile",
+    "type": "transformer",
+    "body": "Plugin for creating elevation profiles.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "field_aggregator",
+    "type": "transformer",
+    "body": "Field aggregator transformer.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "forest_elevation_analysis",
+    "type": "transformer",
+    "body": "Plugin for analyzing the distribution of forest types by elevation.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "forest_holdridge_analysis",
+    "type": "transformer",
+    "body": "Plugin for analyzing the distribution of forests in Holdridge life zones.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "fragmentation_analysis",
+    "type": "transformer",
+    "body": "Plugin for forest fragmentation analysis.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "geospatial_extractor",
+    "type": "transformer",
+    "body": "Plugin for extracting geospatial data",
+    "version": "0.15.5"
+  },
+  {
+    "name": "land_use_analysis",
+    "type": "transformer",
+    "body": "Plugin for a complete analysis of land use.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "multi_column_extractor",
+    "type": "transformer",
+    "body": "Plugin for extracting values from multiple columns",
+    "version": "0.15.5"
+  },
+  {
+    "name": "niamoto_to_dwc_occurrence",
+    "type": "transformer",
+    "body": "Transform Niamoto data to Darwin Core Occurrence format.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "raster_stats",
+    "type": "transformer",
+    "body": "Plugin for extracting statistics from raster data.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "scatter_analysis",
+    "type": "transformer",
+    "body": "Plugin d'analyse de dispersion entre deux champs numériques.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "shape_processor",
+    "type": "transformer",
+    "body": "Plugin for processing complex shapes with additional layers",
+    "version": "0.15.5"
+  },
+  {
+    "name": "statistical_summary",
+    "type": "transformer",
+    "body": "Plugin for calculating statistical summaries",
+    "version": "0.15.5"
+  },
+  {
+    "name": "time_series_analysis",
+    "type": "transformer",
+    "body": "Plugin for analyzing time series data",
+    "version": "0.15.5"
+  },
+  {
+    "name": "top_ranking",
+    "type": "transformer",
+    "body": "Plugin for getting top N items",
+    "version": "0.15.5"
+  },
+  {
+    "name": "transform_chain",
+    "type": "transformer",
+    "body": "Plugin for chaining multiple transformations",
+    "version": "0.15.5"
+  },
+  {
+    "name": "vector_overlay",
+    "type": "transformer",
+    "body": "Plugin for vector overlay analysis.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "bar_plot",
+    "type": "widget",
+    "body": "Widget to display a bar plot using Plotly.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "concentric_rings",
+    "type": "widget",
+    "body": "Widget to display concentric rings for forest cover data.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "diverging_bar_plot",
+    "type": "widget",
+    "body": "Widget to display a diverging bar plot (horizontal or vertical) using Plotly.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "donut_chart",
+    "type": "widget",
+    "body": "Widget to display a donut chart using Plotly.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "hierarchical_nav_widget",
+    "type": "widget",
+    "body": "Interactive hierarchical navigation tree widget.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "info_grid",
+    "type": "widget",
+    "body": "Displays a grid of key information items (KPIs, stats, labels).",
+    "version": "0.15.5"
+  },
+  {
+    "name": "interactive_map",
+    "type": "widget",
+    "body": "Widget to display an interactive map using Plotly Express.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "line_plot",
+    "type": "widget",
+    "body": "Widget to display a line plot using Plotly.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "radial_gauge",
+    "type": "widget",
+    "body": "Widget to display a radial gauge using Plotly.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "raw_data_widget",
+    "type": "widget",
+    "body": "Widget to display raw data in an HTML table.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "scatter_plot",
+    "type": "widget",
+    "body": "Widget to display a scatter plot using Plotly Express.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "stacked_area_plot",
+    "type": "widget",
+    "body": "Widget to display a stacked area chart using Plotly.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "summary_stats",
+    "type": "widget",
+    "body": "Widget to display summary statistics of numeric columns in a DataFrame.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "sunburst_chart",
+    "type": "widget",
+    "body": "Widget to display a sunburst chart using Plotly.",
+    "version": "0.15.5"
+  },
+  {
+    "name": "table_view",
+    "type": "widget",
+    "body": "Widget to display a pandas DataFrame as an HTML table.",
+    "version": "0.15.5"
+  }
+]

--- a/scripts/generate-plugin-manifest.py
+++ b/scripts/generate-plugin-manifest.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Extract plugin metadata from the Niamoto source tree via AST.
+
+Writes `.marketing/plugins.json` — a sorted list of `{name, type, body,
+version}` entries — consumed by the niamoto-site marketing site.
+
+Runs in CI on every push to `main` that touches plugin sources.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGINS_DIR = REPO_ROOT / "src" / "niamoto" / "core" / "plugins"
+OUTPUT = REPO_ROOT / ".marketing" / "plugins.json"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _read_package_version() -> str:
+    """Extract the project version from pyproject.toml."""
+    with PYPROJECT.open("rb") as fh:
+        data = tomllib.load(fh)
+    return data["project"]["version"]
+
+
+def _decorator_name(decorator: ast.expr) -> str | None:
+    """Return the callable name of a decorator, or None."""
+    if isinstance(decorator, ast.Call):
+        func = decorator.func
+        if isinstance(func, ast.Name):
+            return func.id
+        if isinstance(func, ast.Attribute):
+            return func.attr
+    return None
+
+
+def _extract_type_from_register_args(call: ast.Call) -> str | None:
+    """If @register has a second positional arg like PluginType.WIDGET, return 'widget'."""
+    if len(call.args) < 2:
+        return None
+    second = call.args[1]
+    if isinstance(second, ast.Attribute):
+        # e.g., PluginType.WIDGET -> 'widget'
+        return second.attr.lower()
+    return None
+
+
+def _extract_type_from_class_body(cls_node: ast.ClassDef) -> str | None:
+    """Fallback: look for `type = PluginType.X` inside the class body."""
+    for stmt in cls_node.body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name) and target.id == "type":
+                    value = stmt.value
+                    if isinstance(value, ast.Attribute):
+                        return value.attr.lower()
+    return None
+
+
+_BASE_CLASS_TYPE_MAP = {
+    "LoaderPlugin": "loader",
+    "TransformerPlugin": "transformer",
+    "ExporterPlugin": "exporter",
+    "WidgetPlugin": "widget",
+    "DeployerPlugin": "deployer",
+}
+
+
+def _extract_type_from_base_class(cls_node: ast.ClassDef) -> str | None:
+    """Fallback: infer type from the base class name (e.g., DeployerPlugin -> deployer)."""
+    for base in cls_node.bases:
+        if isinstance(base, ast.Name) and base.id in _BASE_CLASS_TYPE_MAP:
+            return _BASE_CLASS_TYPE_MAP[base.id]
+        if isinstance(base, ast.Attribute) and base.attr in _BASE_CLASS_TYPE_MAP:
+            return _BASE_CLASS_TYPE_MAP[base.attr]
+    return None
+
+
+def _first_paragraph(docstring: str | None) -> str:
+    """Return the first paragraph of a docstring, stripped."""
+    if not docstring:
+        return ""
+    return docstring.split("\n\n", 1)[0].strip().replace("\n", " ")
+
+
+def _plugins_in_file(path: Path) -> list[dict[str, Any]]:
+    """Parse a single .py file and return all @register'd plugins."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError as exc:
+        print(f"SyntaxError in {path}: {exc}", file=sys.stderr)
+        return []
+
+    results: list[dict[str, Any]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for deco in node.decorator_list:
+            if _decorator_name(deco) != "register":
+                continue
+            if not isinstance(deco, ast.Call) or not deco.args:
+                continue
+            first_arg = deco.args[0]
+            if not (
+                isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str)
+            ):
+                continue
+            name = first_arg.value
+            ptype = (
+                _extract_type_from_register_args(deco)
+                or _extract_type_from_class_body(node)
+                or _extract_type_from_base_class(node)
+            )
+            if ptype is None:
+                print(
+                    f"Skipped {name} in {path}: cannot determine type", file=sys.stderr
+                )
+                continue
+            results.append(
+                {
+                    "name": name,
+                    "type": ptype,
+                    "body": _first_paragraph(ast.get_docstring(node)),
+                }
+            )
+    return results
+
+
+def extract_plugins(plugins_root: Path) -> list[dict[str, Any]]:
+    """Walk a plugins directory and collect every registered plugin."""
+    collected: list[dict[str, Any]] = []
+    for py_file in sorted(plugins_root.rglob("*.py")):
+        if "__pycache__" in py_file.parts:
+            continue
+        collected.extend(_plugins_in_file(py_file))
+    collected.sort(key=lambda p: (p["type"], p["name"]))
+    return collected
+
+
+def main() -> int:
+    plugins = extract_plugins(PLUGINS_DIR)
+    version = _read_package_version()
+    for plugin in plugins:
+        plugin["version"] = version
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(
+        json.dumps(plugins, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(f"Wrote {len(plugins)} plugins to {OUTPUT.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/niamoto/gui/api/routers/site.py
+++ b/src/niamoto/gui/api/routers/site.py
@@ -20,14 +20,6 @@ _ROOT_INDEX_TEMPLATE = "index.html"
 _ROOT_INDEX_OUTPUT = "index.html"
 
 
-def _default_root_index_page() -> dict[str, Any]:
-    return {
-        "name": "home",
-        "template": _ROOT_INDEX_TEMPLATE,
-        "output_file": _ROOT_INDEX_OUTPUT,
-    }
-
-
 def _normalize_output_alias(output_file: str | None) -> str | None:
     if not output_file:
         return None
@@ -41,15 +33,6 @@ def _is_root_index_page(page: dict[str, Any]) -> bool:
 def _normalize_static_pages(
     static_pages: list[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
-    has_root_index = any(
-        _is_root_index_page(page)
-        or _normalize_output_alias(str(page.get("output_file", "")))
-        == _ROOT_INDEX_OUTPUT
-        for page in static_pages
-    )
-    if not has_root_index:
-        static_pages = [_default_root_index_page(), *static_pages]
-
     normalized_pages: list[dict[str, Any]] = []
     output_aliases: dict[str, str] = {}
 
@@ -653,7 +636,7 @@ async def update_site_config(update: SiteConfigUpdate):
                 "template_dir": "templates/",
                 "output_dir": "exports/web",
             },
-            "static_pages": [_default_root_index_page()],
+            "static_pages": [],
             "groups": [],
         }
         exports.append(web_pages)

--- a/tests/gui/api/routers/test_site.py
+++ b/tests/gui/api/routers/test_site.py
@@ -180,7 +180,7 @@ class TestSiteGroups:
             assert data["navigation"][0]["url"] == "/index.html"
             assert data["footer_navigation"][0]["links"][0]["url"] == "/index.html"
 
-    def test_get_site_config_injects_default_home_page_when_missing(self):
+    def test_get_site_config_keeps_empty_static_pages_when_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             project = Path(temp_dir)
             config_dir = project / "config"
@@ -211,14 +211,7 @@ class TestSiteGroups:
                 assert response.status_code == 200, response.text
 
             data = response.json()
-            assert data["static_pages"] == [
-                {
-                    "name": "home",
-                    "template": "index.html",
-                    "output_file": "index.html",
-                    "context": None,
-                }
-            ]
+            assert data["static_pages"] == []
 
     def test_update_site_config_normalizes_home_output_and_links(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -307,7 +300,7 @@ class TestSiteGroups:
             assert web_pages["params"]["template_dir"] == "templates/"
             assert web_pages["params"]["output_dir"] == "exports/web"
 
-    def test_update_site_config_adds_default_home_page_when_missing(self):
+    def test_update_site_config_persists_empty_static_pages(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             project = Path(temp_dir)
             config_dir = project / "config"
@@ -332,13 +325,7 @@ class TestSiteGroups:
 
             saved_config = yaml.safe_load((config_dir / "export.yml").read_text())
             web_pages = saved_config["exports"][0]
-            assert web_pages["static_pages"] == [
-                {
-                    "name": "home",
-                    "template": "index.html",
-                    "output_file": "index.html",
-                }
-            ]
+            assert web_pages["static_pages"] == []
 
     def test_update_site_config_rejects_multiple_home_templates(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/scripts/test_generate_plugin_manifest.py
+++ b/tests/scripts/test_generate_plugin_manifest.py
@@ -1,0 +1,156 @@
+"""Tests for scripts/generate-plugin-manifest.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "generate-plugin-manifest.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("plugin_manifest", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["plugin_manifest"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def fake_plugins_tree(tmp_path: Path) -> Path:
+    """Create a minimal plugins tree with two registered classes."""
+    root = tmp_path / "plugins"
+    (root / "widgets").mkdir(parents=True)
+    (root / "transformers").mkdir(parents=True)
+
+    (root / "widgets" / "bar_plot.py").write_text(
+        '''
+from niamoto.core.plugins.base import PluginType, register, WidgetPlugin
+
+
+@register("bar_plot", PluginType.WIDGET)
+class BarPlotWidget(WidgetPlugin):
+    """Widget to display a bar plot using Plotly.
+
+    This second paragraph is ignored by the extractor.
+    """
+    pass
+'''.lstrip()
+    )
+
+    (root / "transformers" / "top_ranking.py").write_text(
+        '''
+from niamoto.core.plugins.base import PluginType, register
+
+
+@register("top_ranking", PluginType.TRANSFORMER)
+class TopRanking:
+    """Rank the top N values of a field."""
+    pass
+'''.lstrip()
+    )
+
+    # A file without any @register decorator — should be skipped silently.
+    (root / "widgets" / "_helpers.py").write_text("def helper():\n    return 1\n")
+
+    return root
+
+
+def test_extracts_two_plugins(fake_plugins_tree: Path):
+    module = _load_module()
+    plugins = module.extract_plugins(fake_plugins_tree)
+
+    assert len(plugins) == 2
+    names = {p["name"] for p in plugins}
+    assert names == {"bar_plot", "top_ranking"}
+
+
+def test_output_shape(fake_plugins_tree: Path):
+    module = _load_module()
+    plugins = module.extract_plugins(fake_plugins_tree)
+
+    bar_plot = next(p for p in plugins if p["name"] == "bar_plot")
+    assert bar_plot == {
+        "name": "bar_plot",
+        "type": "widget",
+        "body": "Widget to display a bar plot using Plotly.",
+    }
+
+
+def test_sorted_by_type_then_name(fake_plugins_tree: Path):
+    module = _load_module()
+    plugins = module.extract_plugins(fake_plugins_tree)
+
+    # transformer comes before widget alphabetically
+    assert [p["type"] for p in plugins] == ["transformer", "widget"]
+
+
+def test_handles_missing_docstring(tmp_path: Path):
+    root = tmp_path / "plugins"
+    root.mkdir()
+    (root / "nodoc.py").write_text(
+        """
+from niamoto.core.plugins.base import PluginType, register
+
+
+@register("nodoc", PluginType.LOADER)
+class NoDocLoader:
+    pass
+""".lstrip()
+    )
+
+    module = _load_module()
+    plugins = module.extract_plugins(root)
+    assert plugins == [{"name": "nodoc", "type": "loader", "body": ""}]
+
+
+def test_type_fallback_from_class_attr(tmp_path: Path):
+    """If @register is called without a type, fall back on the `type` class attr."""
+    root = tmp_path / "plugins"
+    root.mkdir()
+    (root / "implicit.py").write_text(
+        '''
+from niamoto.core.plugins.base import PluginType, register
+
+
+@register("implicit")
+class ImplicitExporter:
+    """An exporter declaring its type via class attribute."""
+    type = PluginType.EXPORTER
+'''.lstrip()
+    )
+
+    module = _load_module()
+    plugins = module.extract_plugins(root)
+    assert plugins[0]["type"] == "exporter"
+
+
+def test_type_fallback_from_base_class(tmp_path: Path):
+    """If neither @register nor class body specifies type, infer from base class name."""
+    root = tmp_path / "plugins"
+    root.mkdir()
+    (root / "vercel.py").write_text(
+        '''
+from niamoto.core.plugins.base import DeployerPlugin, register
+
+
+@register("vercel")
+class VercelDeployer(DeployerPlugin):
+    """Deploy static sites to Vercel via the Deployments API."""
+    pass
+'''.lstrip()
+    )
+
+    module = _load_module()
+    plugins = module.extract_plugins(root)
+    assert plugins == [
+        {
+            "name": "vercel",
+            "type": "deployer",
+            "body": "Deploy static sites to Vercel via the Deployments API.",
+        }
+    ]


### PR DESCRIPTION
AST-based plugin extractor + GH Actions workflow that regenerates .marketing/plugins.json and pings the niamoto-site Coolify webhook on push. Spec: niamoto-site/docs/superpowers/specs/2026-04-20-dynamic-content-from-niamoto-repo-design.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated marketing site sync workflow that regenerates plugin registry on repository updates.
  * Implemented plugin manifest generation to dynamically catalog and document available plugins.

* **Chores**
  * Removed automatic default page injection in site configuration.

* **Tests**
  * Added comprehensive tests for plugin manifest generation.
  * Updated site configuration tests to reflect simplified page handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->