### PR TITLE
ci(marketing-sync): use Tailscale GitHub Action to reach Coolify on tailnet

### DIFF
--- a/.github/workflows/marketing-sync.yml
+++ b/.github/workflows/marketing-sync.yml
@@ -44,9 +44,17 @@ jobs:
             echo "Plugin manifest unchanged — skipping commit."
           fi
 
-      - name: Trigger niamoto-site rebuild
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci-github
+          version: latest
+
+      - name: Trigger niamoto-site rebuild via Coolify
         run: |
-          curl --fail -X GET "$COOLIFY_WEBHOOK" \
+          curl --fail --silent --show-error -X GET "$COOLIFY_WEBHOOK" \
             -H "Authorization: Bearer $COOLIFY_TOKEN"
         env:
           COOLIFY_WEBHOOK: ${{ secrets.COOLIFY_WEBHOOK }}


### PR DESCRIPTION
Coolify API is tailnet-only (by design, see /Users/julienbarbe/Dev/server/6gardens/plans/docs-server-coolify-deployment.md). Swap the blocked public webhook call for a Tailscale GH Action that joins the tailnet for the job duration and hits Coolify directly at 100.83.205.6:8000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the website rebuild workflow to establish a secure connection before triggering site updates, ensuring more reliable and secure deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->