### PR TITLE
fix: address site editor review feedback

### DIFF
--- a/src/niamoto/gui/ui/src/features/site/components/SiteBuilder.test.tsx
+++ b/src/niamoto/gui/ui/src/features/site/components/SiteBuilder.test.tsx
@@ -495,4 +495,47 @@ describe('SiteBuilder workbench preview behavior', () => {
       root.unmount()
     })
   })
+
+  it('offers a header restore button for closed collection previews', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    const setPreviewState = vi.fn()
+
+    stateRef.value = buildState({
+      siteConfig: buildConfiguredSiteConfig(),
+      selection: { type: 'group', id: 'taxons' },
+      groups: [
+        {
+          name: 'taxons',
+          index_generator: { enabled: true },
+          index_output_pattern: 'taxons/index.html',
+        },
+      ],
+    })
+    workbenchRef.value = buildWorkbenchPreferences({
+      previewState: 'closed',
+      setPreviewState,
+    })
+
+    await act(async () => {
+      root.render(<SiteBuilder />)
+    })
+
+    expect(container.innerHTML).toContain('Group page viewer')
+    expect(container.innerHTML).not.toContain('Group preview')
+
+    const restoreButton = container.querySelector('[data-testid="preview-restore-bar"]')
+    expect(restoreButton).not.toBeNull()
+
+    await act(async () => {
+      ;(restoreButton as HTMLButtonElement).click()
+    })
+
+    expect(setPreviewState).toHaveBeenCalledWith('open')
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
 })

--- a/src/niamoto/gui/ui/src/features/site/components/SiteBuilder.tsx
+++ b/src/niamoto/gui/ui/src/features/site/components/SiteBuilder.tsx
@@ -13,6 +13,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
+  Eye,
   Loader2,
   Save,
   AlertCircle,
@@ -589,6 +590,17 @@ export function SiteBuilder({ initialSection = 'pages' }: SiteBuilderProps) {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          {showPreviewRestore && state.selection?.type !== 'page' && (
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="preview-restore-bar"
+              onClick={handleOpenPreview}
+            >
+              <Eye className="h-4 w-4 mr-1" />
+              {t('preview.title')}
+            </Button>
+          )}
           {!siteNeedsSetup && !showWizard && (
             <Button
               variant="ghost"

--- a/src/niamoto/gui/ui/src/features/site/components/forms/MarkdownContentField.test.tsx
+++ b/src/niamoto/gui/ui/src/features/site/components/forms/MarkdownContentField.test.tsx
@@ -195,6 +195,77 @@ describe('MarkdownContentField', () => {
 
     expect(harness.container.textContent).toContain('Changed draft markdown')
 
+    const writeButton = harness.container.querySelector(
+      'button[aria-label="site:pageEditor.writeMode"]'
+    ) as HTMLButtonElement | null
+    expect(writeButton).not.toBeNull()
+
+    await act(async () => {
+      writeButton?.click()
+    })
+
+    expect(
+      harness.container
+        .querySelector('[data-testid="markdown-write"]')
+        ?.getAttribute('data-content')
+    ).toBe('Changed draft markdown')
+
+    await harness.unmount()
+  })
+
+  it('clears the dirty draft when switching to another source file', async () => {
+    const harness = createHarness()
+    const onContentSourceChange = vi.fn()
+
+    useFileContent.mockImplementation((path: string | null) => {
+      if (path === 'templates/content/terms.md') {
+        return {
+          data: undefined,
+          error: null,
+          isLoading: true,
+        }
+      }
+
+      return {
+        data: { content: 'Initial markdown' },
+        error: null,
+        isLoading: false,
+      }
+    })
+
+    await harness.render(
+      <MarkdownContentField
+        baseName="about"
+        contentSource="templates/content/about.md"
+        onContentSourceChange={onContentSourceChange}
+      />
+    )
+
+    await act(async () => {
+      ;(harness.container.querySelector('[data-testid="markdown-change"]') as HTMLButtonElement).click()
+    })
+
+    const dirtySaveButton = Array.from(harness.container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('site:pageEditor.save')
+    ) as HTMLButtonElement | undefined
+    expect(dirtySaveButton?.disabled).toBe(false)
+
+    await harness.render(
+      <MarkdownContentField
+        baseName="about"
+        contentSource="templates/content/terms.md"
+        onContentSourceChange={onContentSourceChange}
+      />
+    )
+
+    const saveButton = Array.from(harness.container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('site:pageEditor.save')
+    ) as HTMLButtonElement | undefined
+
+    expect(saveButton?.disabled).toBe(true)
+    expect(harness.container.textContent).toContain('terms.md')
+    expect(mutateAsync).not.toHaveBeenCalled()
+
     await harness.unmount()
   })
 
@@ -230,6 +301,11 @@ describe('MarkdownContentField', () => {
       path: 'templates/content/about.md',
       content: 'Changed draft markdown',
     })
+    expect(
+      harness.container
+        .querySelector('[data-testid="markdown-write"]')
+        ?.getAttribute('data-content')
+    ).toBe('Changed draft markdown')
 
     await harness.unmount()
   })

--- a/src/niamoto/gui/ui/src/features/site/components/forms/MarkdownContentField.tsx
+++ b/src/niamoto/gui/ui/src/features/site/components/forms/MarkdownContentField.tsx
@@ -119,6 +119,8 @@ export function MarkdownContentField({
   const [isSaving, setIsSaving] = useState(false)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const previousSingleFilePathRef = useRef<string | null>(null)
+  const hasUnsavedChangesRef = useRef(false)
 
   const getDefaultFilePath = useCallback(() => `templates/content/${baseName}.md`, [baseName])
   const getMultilingualBasePath = useCallback(() => `templates/content/${baseName}`, [baseName])
@@ -148,12 +150,40 @@ export function MarkdownContentField({
     }
   }, [contentSource])
 
+  const resetSingleFileDraft = useCallback((content = '') => {
+    setEditedContent(content)
+    setHasUnsavedChanges(false)
+    setIsSaving(false)
+  }, [])
+
   useEffect(() => {
-    if (fileContentData?.content !== undefined) {
-      setEditedContent(fileContentData.content)
-      setHasUnsavedChanges(false)
+    hasUnsavedChangesRef.current = hasUnsavedChanges
+  }, [hasUnsavedChanges])
+
+  useEffect(() => {
+    const previousPath = previousSingleFilePathRef.current
+    const pathChanged = previousPath !== singleFilePath
+    previousSingleFilePathRef.current = singleFilePath
+
+    if (!singleFilePath) {
+      resetSingleFileDraft()
+      return
     }
-  }, [fileContentData?.content])
+
+    if (pathChanged) {
+      resetSingleFileDraft(fileContentData?.content ?? '')
+      setViewMode('write')
+      return
+    }
+
+    if (!hasUnsavedChangesRef.current && fileContentData?.content !== undefined) {
+      setEditedContent(fileContentData.content)
+    }
+  }, [
+    fileContentData?.content,
+    resetSingleFileDraft,
+    singleFilePath,
+  ])
 
   useEffect(() => {
     if (!contentSource) {
@@ -164,7 +194,7 @@ export function MarkdownContentField({
   const handleContentModeChange = (mode: ContentMode) => {
     setContentMode(mode)
     setViewMode('write')
-    setHasUnsavedChanges(false)
+    resetSingleFileDraft()
     setSourceControlsOpen(false)
 
     if (mode === 'single') {
@@ -219,6 +249,7 @@ export function MarkdownContentField({
     try {
       const result = await uploadMutation.mutateAsync({ file, folder: 'templates/content' })
       await refetchFiles()
+      resetSingleFileDraft()
       onContentSourceChange(result.path)
       setViewMode('write')
       setSourceControlsOpen(false)
@@ -235,6 +266,7 @@ export function MarkdownContentField({
   }
 
   const handleFileSelection = (path: string) => {
+    resetSingleFileDraft()
     onContentSourceChange(path || null)
     setViewMode('write')
     setSourceControlsOpen(false)
@@ -242,8 +274,7 @@ export function MarkdownContentField({
 
   const handleClearFile = () => {
     onContentSourceChange(null)
-    setEditedContent('')
-    setHasUnsavedChanges(false)
+    resetSingleFileDraft()
     setViewMode('write')
     setSourceControlsOpen(true)
   }
@@ -406,7 +437,7 @@ export function MarkdownContentField({
           style={{ minHeight }}
         >
           <pre className="whitespace-pre-wrap font-mono text-sm text-muted-foreground">
-            {editedContent || fileContentData?.content || t('site:pageEditor.noContent')}
+            {editedContent || t('site:pageEditor.noContent')}
           </pre>
         </div>
       )
@@ -417,7 +448,7 @@ export function MarkdownContentField({
         <Suspense fallback={editorFallback}>
           <MarkdownEditor
             key={singleFilePath}
-            initialContent={fileContentData?.content ?? editedContent}
+            initialContent={editedContent}
             onChange={handleContentChange}
             placeholder={placeholder || t('site:pageEditor.markdownPlaceholder')}
             className={variant === 'authoring' ? 'border-border/70 shadow-none' : undefined}
@@ -486,7 +517,7 @@ export function MarkdownContentField({
                 <Button
                   size="sm"
                   onClick={handleSave}
-                  disabled={!hasUnsavedChanges || isSaving}
+                  disabled={!hasUnsavedChanges || isSaving || fileContentLoading}
                 >
                   {isSaving ? (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/niamoto/gui/ui/src/features/site/lib/markdownTables.test.ts
+++ b/src/niamoto/gui/ui/src/features/site/lib/markdownTables.test.ts
@@ -60,4 +60,34 @@ describe('markdownTables', () => {
     expect(tableNodeToMarkdown(tableNode, getText)).toContain('| Lycophytes')
     expect(tableNodeToMarkdown(tableNode, getText)).toContain('---')
   })
+
+  it('escapes literal pipes when serializing table cells', () => {
+    const tableNode: JSONContent = {
+      type: 'table',
+      content: [
+        {
+          type: 'tableRow',
+          content: [
+            markdownTableTestUtils.createTableCell('tableHeader', 'Label'),
+            markdownTableTestUtils.createTableCell('tableHeader', 'Value'),
+          ],
+        },
+        {
+          type: 'tableRow',
+          content: [
+            markdownTableTestUtils.createTableCell('tableCell', 'Alpha | Beta'),
+            markdownTableTestUtils.createTableCell('tableCell', '42'),
+          ],
+        },
+      ],
+    }
+
+    const markdown = tableNodeToMarkdown(tableNode, getText)
+
+    expect(markdown).toContain('Alpha \\| Beta')
+
+    const parsed = parseMarkdownTable(markdown, parseInlineContent)
+    expect(getText(parsed?.content?.[1]?.content?.[0] as JSONContent)).toBe('Alpha | Beta')
+    expect(parsed?.content?.[1]?.content).toHaveLength(2)
+  })
 })

--- a/src/niamoto/gui/ui/src/features/site/lib/markdownTables.ts
+++ b/src/niamoto/gui/ui/src/features/site/lib/markdownTables.ts
@@ -141,6 +141,10 @@ function extractTableCellText(
   return text.replace(/\s*\n+\s*/g, ' ').trim()
 }
 
+function escapeMarkdownTableCell(text: string): string {
+  return text.replace(/\|/g, '\\|')
+}
+
 function padRow(cells: string[], columnCount: number): string[] {
   return Array.from({ length: columnCount }, (_, index) => cells[index] ?? '')
 }
@@ -155,7 +159,9 @@ export function tableNodeToMarkdown(
   }
 
   const cellRows = rows.map((row) =>
-    (row.content ?? []).map((cell) => extractTableCellText(cell, getText))
+    (row.content ?? []).map((cell) =>
+      escapeMarkdownTableCell(extractTableCellText(cell, getText))
+    )
   )
 
   const columnCount = Math.max(...cellRows.map((row) => row.length))
@@ -181,5 +187,6 @@ export function tableNodeToMarkdown(
 
 export const markdownTableTestUtils = {
   createTableCell,
+  escapeMarkdownTableCell,
   splitMarkdownTableRow,
 }


### PR DESCRIPTION
## Summary
- preserve markdown drafts when switching between write/source modes
- reset dirty markdown state when changing source files to avoid cross-file overwrites
- escape literal pipes when serializing markdown tables
- add a preview restore action for non-page Site Builder selections

## Testing
- pnpm exec vitest run src/features/site/components/forms/MarkdownContentField.test.tsx src/features/site/lib/markdownTables.test.ts src/features/site/components/SiteBuilder.test.tsx
- pnpm run build