### PR TITLE
ci: update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get install -y gdal-bin libgdal-dev libproj-dev
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install project with docs extras
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,17 +37,17 @@ jobs:
         sudo apt-get install -y gdal-bin libgdal-dev libproj-dev
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
 
     - name: Set up pnpm
       if: matrix.python-version == '3.12'
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 10.17.1
 
     - name: Set up Node.js
       if: matrix.python-version == '3.12'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: pnpm
@@ -78,7 +78,7 @@ jobs:
         pnpm test:coverage
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: ./coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
 
     - name: Upload frontend coverage to Codecov
       if: matrix.python-version == '3.12'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: ./src/niamoto/gui/ui/coverage/lcov.info
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- update test workflow actions to Node 24-compatible majors
- update docs workflow setup-uv action
- move Codecov uploads to v6 to avoid nested github-script Node 20 warnings

## Validation
- uv run pre-commit run check-yaml --files .github/workflows/tests.yml .github/workflows/docs.yml
- commit hooks passed