### PR TITLE
Fix collection block previews

### DIFF
--- a/src/niamoto/core/plugins/widgets/bar_plot.py
+++ b/src/niamoto/core/plugins/widgets/bar_plot.py
@@ -10,9 +10,14 @@ from niamoto.common.utils.data_access import convert_to_dataframe
 from niamoto.core.plugins.base import WidgetPlugin, PluginType, register
 from niamoto.core.plugins.models import BasePluginParams
 from niamoto.core.plugins.widgets.plotly_utils import (
+    MUTED_CHART_COLORS,
     apply_plotly_defaults,
-    render_plotly_figure,
+    generate_muted_discrete_colors,
+    generate_muted_gradient_colors,
     get_plotly_dependencies,
+    hex_to_rgb as _hex_to_rgb,
+    render_plotly_figure,
+    rgb_to_hex as _rgb_to_hex,
 )
 
 logger = logging.getLogger(__name__)
@@ -20,129 +25,24 @@ logger = logging.getLogger(__name__)
 
 def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
     """Convert hex color to RGB."""
-    hex_color = hex_color.lstrip("#")
-    return tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+    return _hex_to_rgb(hex_color)
 
 
 def rgb_to_hex(r: int, g: int, b: int) -> str:
     """Convert RGB to hex."""
-    return f"#{r:02x}{g:02x}{b:02x}"
+    return _rgb_to_hex(r, g, b)
 
 
 def generate_gradient_colors(
     base_color: str, count: int, mode: str = "luminance"
 ) -> List[str]:
-    """Generate a gradient of colors based on a base color.
-
-    Args:
-        base_color: Base color in hex format (e.g., '#1fb99d')
-        count: Number of colors to generate
-        mode: Gradient mode - 'luminance' (light to dark) or 'saturation' (saturated to pale)
-
-    Returns:
-        List of hex color strings forming a gradient
-    """
-    if count <= 0:
-        return []
-
-    if count == 1:
-        return [base_color]
-
-    # Convert base color to RGB
-    r, g, b = hex_to_rgb(base_color)
-
-    colors = []
-
-    if mode == "luminance":
-        # Create gradient from lighter to darker
-        for i in range(count):
-            # Calculate factor: 0.3 (lightest) to 1.0 (original color)
-            factor = 0.3 + (0.7 * i / (count - 1))
-
-            # Apply factor to create gradient
-            new_r = int(r * factor + 255 * (1 - factor))
-            new_g = int(g * factor + 255 * (1 - factor))
-            new_b = int(b * factor + 255 * (1 - factor))
-
-            colors.append(rgb_to_hex(new_r, new_g, new_b))
-
-    elif mode == "saturation":
-        # Create gradient from saturated to pale
-        for i in range(count):
-            # Calculate factor: 1.0 (full saturation) to 0.3 (pale)
-            factor = 1.0 - (0.7 * i / (count - 1))
-
-            # Mix with gray to reduce saturation
-            gray = 128
-            new_r = int(r * factor + gray * (1 - factor))
-            new_g = int(g * factor + gray * (1 - factor))
-            new_b = int(b * factor + gray * (1 - factor))
-
-            colors.append(rgb_to_hex(new_r, new_g, new_b))
-
-    return colors
+    """Generate a restrained gradient of colors based on a base color."""
+    return generate_muted_gradient_colors(base_color, count, mode)
 
 
 def generate_colors(count: int) -> List[str]:
-    """Generate harmonious colors using HSL color space and golden ratio.
-
-    Args:
-        count: Number of colors to generate
-
-    Returns:
-        List of hex color strings
-    """
-
-    def hsl_to_rgb(h: float, s: float, lightness: float) -> tuple[int, int, int]:
-        """Convert HSL to RGB."""
-        if s == 0:
-            r = g = b = lightness  # achromatic
-        else:
-
-            def hue_to_rgb(p: float, q: float, t: float) -> float:
-                if t < 0:
-                    t += 1
-                if t > 1:
-                    t -= 1
-                if t < 1 / 6:
-                    return p + (q - p) * 6 * t
-                if t < 1 / 2:
-                    return q
-                if t < 2 / 3:
-                    return p + (q - p) * (2 / 3 - t) * 6
-                return p
-
-            q = (
-                lightness * (1 + s)
-                if lightness < 0.5
-                else lightness + s - lightness * s
-            )
-            p = 2 * lightness - q
-            r = hue_to_rgb(p, q, h + 1 / 3)
-            g = hue_to_rgb(p, q, h)
-            b = hue_to_rgb(p, q, h - 1 / 3)
-
-        return (round(r * 255), round(g * 255), round(b * 255))
-
-    def rgb_to_hex(r: int, g: int, b: int) -> str:
-        """Convert RGB to hex."""
-        return f"#{r:02x}{g:02x}{b:02x}"
-
-    colors = []
-    for i in range(count):
-        # Use golden ratio to spread hues evenly
-        hue = (i * 0.618033988749895) % 1
-
-        # Vary saturation slightly
-        saturation = 0.5 + (i % 3) * 0.1
-
-        # Vary lightness to create contrast
-        lightness = 0.4 + (i % 2) * 0.2
-
-        r, g, b = hsl_to_rgb(hue, saturation, lightness)
-        colors.append(rgb_to_hex(r, g, b))
-
-    return colors
+    """Generate restrained colors for automatic chart coloring."""
+    return generate_muted_discrete_colors(count)
 
 
 def _resolve_bar_colors(
@@ -495,7 +395,7 @@ class BarPlotParams(BasePluginParams):
     )
     gradient_color: Optional[str] = Field(
         default=None,
-        description="Couleur de base pour gradient (ex: '#1fb99d')",
+        description="Couleur de base pour gradient (ex: '#4f8068')",
         json_schema_extra={"ui:widget": "color", "ui:group": "4_colors", "ui:order": 3},
     )
     gradient_mode: Optional[str] = Field(
@@ -1000,7 +900,7 @@ class BarPlotWidget(WidgetPlugin):
 
             # Handle automatic coloring
             color_field = params.color_field
-            color_discrete_sequence = None
+            color_discrete_sequence = MUTED_CHART_COLORS
             color_discrete_map = params.color_discrete_map
 
             # Check if gradient color is specified
@@ -1142,6 +1042,8 @@ class BarPlotWidget(WidgetPlugin):
         marker_kwargs: Dict[str, Any] = {}
         if color_values is not None:
             marker_kwargs["color"] = color_values
+        else:
+            marker_kwargs["color"] = MUTED_CHART_COLORS[0]
 
         value_series = (
             df_plot[params.x_axis]

--- a/src/niamoto/core/plugins/widgets/donut_chart.py
+++ b/src/niamoto/core/plugins/widgets/donut_chart.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, ConfigDict
 from niamoto.core.plugins.base import WidgetPlugin, PluginType, register
 from niamoto.core.plugins.models import BasePluginParams
 from niamoto.core.plugins.widgets.plotly_utils import (
+    MUTED_CHART_COLORS,
     apply_plotly_defaults,
     get_plotly_dependencies,
     render_plotly_figure,
@@ -211,18 +212,7 @@ class DonutChartWidget(WidgetPlugin):
                 logger.error(f"Error creating subplots: {e}", exc_info=True)
                 return f"<p class='error'>Error setting up subplots: {html.escape(str(e))}</p>"
 
-            default_colors = params.color_discrete_sequence or [
-                "blue",
-                "green",
-                "red",
-                "yellow",
-                "orange",
-                "purple",
-                "pink",
-                "brown",
-                "gray",
-                "black",
-            ]
+            default_colors = params.color_discrete_sequence or MUTED_CHART_COLORS
             traces_added = 0
 
             for i, subplot_conf in enumerate(params.subplots):
@@ -462,7 +452,9 @@ class DonutChartWidget(WidgetPlugin):
                                 hole=params.hole_size,
                                 textinfo=params.text_info,
                                 hoverinfo="label+percent+value",
-                                marker_colors=params.color_discrete_sequence,
+                                marker_colors=(
+                                    params.color_discrete_sequence or MUTED_CHART_COLORS
+                                ),
                                 sort=True,
                             )
                         ]

--- a/src/niamoto/core/plugins/widgets/plotly_utils.py
+++ b/src/niamoto/core/plugins/widgets/plotly_utils.py
@@ -5,13 +5,110 @@ This module provides common functionality for all Plotly widgets,
 including consistent configuration and styling.
 """
 
-from typing import Dict, Any, Set
+import colorsys
+from typing import Any, Dict, List, Set
 
 # Plotly bundle paths for the exported site.
 # Core bundle — all chart types except maps (~1.3 MB).
 PLOTLY_CORE_URL = "/assets/js/vendor/plotly/plotly-niamoto-core.min.js"
 # Maps bundle — core + scattermap/choroplethmap (~2.2 MB).
 PLOTLY_MAPS_URL = "/assets/js/vendor/plotly/plotly-niamoto-maps.min.js"
+
+# Shared palette for automatically generated chart colors. The hues stay varied,
+# but avoid the highly saturated default Plotly/HTML named colors.
+MUTED_CHART_COLORS = [
+    "#4f8068",
+    "#6d8796",
+    "#b07f4f",
+    "#8b6f9b",
+    "#b76f63",
+    "#6c8f45",
+    "#9a8d58",
+    "#5f7f88",
+    "#a36f82",
+    "#7f7f72",
+]
+
+
+def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    """Convert hex color to RGB."""
+    hex_color = hex_color.lstrip("#")
+    return tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def rgb_to_hex(r: int, g: int, b: int) -> str:
+    """Convert RGB to hex."""
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _mix_hex_colors(hex_color: str, target_color: str, ratio: float) -> str:
+    """Mix a hex color with a target color."""
+    ratio = max(0.0, min(1.0, ratio))
+    source_rgb = hex_to_rgb(hex_color)
+    target_rgb = hex_to_rgb(target_color)
+    mixed_rgb = [
+        round(source * (1 - ratio) + target * ratio)
+        for source, target in zip(source_rgb, target_rgb)
+    ]
+    return rgb_to_hex(*mixed_rgb)
+
+
+def _soften_hex_color(hex_color: str) -> str:
+    """Reduce saturation while keeping the original hue recognizable."""
+    r, g, b = [channel / 255 for channel in hex_to_rgb(hex_color)]
+    h, lightness, saturation = colorsys.rgb_to_hls(r, g, b)
+    saturation *= 0.68
+    if lightness < 0.5:
+        lightness += (0.5 - lightness) * 0.18
+    softened = colorsys.hls_to_rgb(h, lightness, saturation)
+    return rgb_to_hex(*(round(channel * 255) for channel in softened))
+
+
+def generate_muted_gradient_colors(
+    base_color: str, count: int, mode: str = "luminance"
+) -> List[str]:
+    """Generate a restrained gradient based on a base color."""
+    if count <= 0:
+        return []
+
+    if count == 1:
+        return [base_color]
+
+    muted_base = _soften_hex_color(base_color)
+    colors = []
+
+    if mode == "luminance":
+        for i in range(count):
+            factor = 0.35 + (0.65 * i / (count - 1))
+            colors.append(_mix_hex_colors("#f7f5f0", muted_base, factor))
+    elif mode == "saturation":
+        neutral = "#8f8b84"
+        for i in range(count):
+            factor = 0.92 - (0.52 * i / (count - 1))
+            colors.append(_mix_hex_colors(neutral, muted_base, factor))
+
+    return colors
+
+
+def generate_muted_discrete_colors(count: int) -> List[str]:
+    """Generate varied, low-saturation colors for automatic chart coloring."""
+    if count <= 0:
+        return []
+
+    colors = []
+    palette_size = len(MUTED_CHART_COLORS)
+    for i in range(count):
+        base_color = MUTED_CHART_COLORS[i % palette_size]
+        cycle = i // palette_size
+        if cycle == 0:
+            colors.append(base_color)
+            continue
+
+        target = "#f7f5f0" if cycle % 2 else "#28313a"
+        ratio = min(0.12 + 0.08 * ((cycle - 1) // 2), 0.36)
+        colors.append(_mix_hex_colors(base_color, target, ratio))
+
+    return colors
 
 
 def get_plotly_config() -> Dict[str, Any]:
@@ -43,6 +140,7 @@ def get_plotly_layout_defaults() -> Dict[str, Any]:
     """
     return {
         "annotations": [],  # Remove "Produced with Plotly" watermark
+        "colorway": MUTED_CHART_COLORS,
         "margin": {"r": 10, "t": 30, "l": 10, "b": 10},
     }
 

--- a/src/niamoto/core/plugins/widgets/plotly_utils.py
+++ b/src/niamoto/core/plugins/widgets/plotly_utils.py
@@ -64,6 +64,38 @@ def _soften_hex_color(hex_color: str) -> str:
     return rgb_to_hex(*(round(channel * 255) for channel in softened))
 
 
+def _derive_muted_color(hex_color: str, index: int, cycle: int) -> str:
+    """Create a muted color variation without collapsing to repeated shades."""
+    r, g, b = [channel / 255 for channel in hex_to_rgb(hex_color)]
+    hue, lightness, saturation = colorsys.rgb_to_hls(r, g, b)
+
+    hue = (hue + (0.061 * cycle) + (0.013 * index)) % 1.0
+    lightness_offsets = [-0.12, 0.1, -0.06, 0.06, -0.02, 0.14]
+    lightness = max(0.34, min(0.72, lightness + lightness_offsets[cycle % 6]))
+    saturation = max(0.18, min(0.44, saturation * (0.72 + 0.04 * (cycle % 4))))
+
+    derived = colorsys.hls_to_rgb(hue, lightness, saturation)
+    return rgb_to_hex(*(round(channel * 255) for channel in derived))
+
+
+def _make_unique_color(color: str, seen_colors: Set[str]) -> str:
+    """Return a nearby muted color that has not already been emitted."""
+    if color not in seen_colors:
+        return color
+
+    r, g, b = [channel / 255 for channel in hex_to_rgb(color)]
+    hue, lightness, saturation = colorsys.rgb_to_hls(r, g, b)
+    for attempt in range(1, 512):
+        next_hue = (hue + 0.017 * attempt) % 1.0
+        next_lightness = max(0.34, min(0.72, lightness + 0.015 * ((attempt % 9) - 4)))
+        adjusted = colorsys.hls_to_rgb(next_hue, next_lightness, saturation)
+        candidate = rgb_to_hex(*(round(channel * 255) for channel in adjusted))
+        if candidate not in seen_colors:
+            return candidate
+
+    raise ValueError("Unable to generate a unique muted color")
+
+
 def generate_muted_gradient_colors(
     base_color: str, count: int, mode: str = "luminance"
 ) -> List[str]:
@@ -96,17 +128,20 @@ def generate_muted_discrete_colors(count: int) -> List[str]:
         return []
 
     colors = []
+    seen_colors: Set[str] = set()
     palette_size = len(MUTED_CHART_COLORS)
     for i in range(count):
         base_color = MUTED_CHART_COLORS[i % palette_size]
         cycle = i // palette_size
         if cycle == 0:
             colors.append(base_color)
+            seen_colors.add(base_color)
             continue
 
-        target = "#f7f5f0" if cycle % 2 else "#28313a"
-        ratio = min(0.12 + 0.08 * ((cycle - 1) // 2), 0.36)
-        colors.append(_mix_hex_colors(base_color, target, ratio))
+        color = _derive_muted_color(base_color, i % palette_size, cycle)
+        color = _make_unique_color(color, seen_colors)
+        colors.append(color)
+        seen_colors.add(color)
 
     return colors
 

--- a/src/niamoto/core/plugins/widgets/radial_gauge.py
+++ b/src/niamoto/core/plugins/widgets/radial_gauge.py
@@ -16,6 +16,14 @@ from niamoto.core.plugins.widgets.plotly_utils import (
 
 logger = logging.getLogger(__name__)
 
+GAUGE_DEFAULT_COLOR = "#6d8796"
+GAUGE_CONTEXTUAL_LOW_COLOR = "#b76f63"
+GAUGE_CONTEXTUAL_MEDIUM_COLOR = "#b07f4f"
+GAUGE_CONTEXTUAL_HIGH_COLOR = "#4f8068"
+GAUGE_RANGE_BACKGROUND = "#f0f0ed"
+GAUGE_RANGE_HIGHLIGHT = "#e5ece6"
+GAUGE_THRESHOLD_COLOR = "#5f7f88"
+
 
 # Pydantic model for Radial Gauge parameters validation
 class RadialGaugeParams(BasePluginParams):
@@ -109,7 +117,7 @@ class RadialGaugeParams(BasePluginParams):
         json_schema_extra={"ui:widget": "json"},
     )
     bar_color: Optional[str] = Field(
-        default="cornflowerblue",
+        default=GAUGE_DEFAULT_COLOR,
         description="Color of the gauge's value bar",
         json_schema_extra={"ui:widget": "color"},
     )
@@ -332,11 +340,11 @@ class RadialGaugeWidget(WidgetPlugin):
             # Determine color based on value position in range
             value_ratio = (numeric_value - min_value) / (gauge_max - min_value)
             if value_ratio < 0.33:
-                bar_color = "#f02828"  # Red for low values
+                bar_color = GAUGE_CONTEXTUAL_LOW_COLOR
             elif value_ratio < 0.66:
-                bar_color = "#fe6a00"  # Orange for medium values
+                bar_color = GAUGE_CONTEXTUAL_MEDIUM_COLOR
             else:
-                bar_color = "#049f50"  # Green for high values
+                bar_color = GAUGE_CONTEXTUAL_HIGH_COLOR
             # Use same thickness as minimal style
             bar_thickness = 0.8
 
@@ -383,26 +391,38 @@ class RadialGaugeWidget(WidgetPlugin):
                     steps = [
                         {
                             "range": [min_value, range_min],
-                            "color": "#f0f0f0",
+                            "color": GAUGE_RANGE_BACKGROUND,
                         },  # Below min
                         {
                             "range": [range_min, range_max],
-                            "color": "#e3f2fd",
+                            "color": GAUGE_RANGE_HIGHLIGHT,
                         },  # Data range
                         {
                             "range": [range_max, gauge_max],
-                            "color": "#f0f0f0",
+                            "color": GAUGE_RANGE_BACKGROUND,
                         },  # Above max
                     ]
                 elif range_min is not None:
                     steps = [
-                        {"range": [min_value, range_min], "color": "#f0f0f0"},
-                        {"range": [range_min, gauge_max], "color": "#e3f2fd"},
+                        {
+                            "range": [min_value, range_min],
+                            "color": GAUGE_RANGE_BACKGROUND,
+                        },
+                        {
+                            "range": [range_min, gauge_max],
+                            "color": GAUGE_RANGE_HIGHLIGHT,
+                        },
                     ]
                 elif range_max is not None:
                     steps = [
-                        {"range": [min_value, range_max], "color": "#e3f2fd"},
-                        {"range": [range_max, gauge_max], "color": "#f0f0f0"},
+                        {
+                            "range": [min_value, range_max],
+                            "color": GAUGE_RANGE_HIGHLIGHT,
+                        },
+                        {
+                            "range": [range_max, gauge_max],
+                            "color": GAUGE_RANGE_BACKGROUND,
+                        },
                     ]
 
                 if steps:
@@ -411,7 +431,7 @@ class RadialGaugeWidget(WidgetPlugin):
                 # Add threshold marker for the max value
                 if range_max is not None and effective_field != "max":
                     gauge_args["gauge"]["threshold"] = {
-                        "line": {"color": "#1976d2", "width": 2},
+                        "line": {"color": GAUGE_THRESHOLD_COLOR, "width": 2},
                         "thickness": 0.75,
                         "value": range_max,
                     }
@@ -448,7 +468,7 @@ class RadialGaugeWidget(WidgetPlugin):
                 gauge_args["gauge"]["bar"]["color"] = params.bar_color
             else:
                 # Default gradient color
-                gauge_args["gauge"]["bar"]["color"] = "#1fb99d"
+                gauge_args["gauge"]["bar"]["color"] = GAUGE_CONTEXTUAL_HIGH_COLOR
 
         elif params.style_mode == "classic" and params.steps:
             # Classic style with defined color steps

--- a/src/niamoto/gui/api/routers/config.py
+++ b/src/niamoto/gui/api/routers/config.py
@@ -1772,10 +1772,14 @@ async def update_export_widget(
                 "params": update.params,
             }
         )
-        if update.title is not None:
-            new_widget["title"] = update.title
-        if update.description is not None:
-            new_widget["description"] = update.description
+        for metadata_field in ("title", "description"):
+            if metadata_field not in update.model_fields_set:
+                continue
+            metadata_value = getattr(update, metadata_field)
+            if metadata_value is None:
+                new_widget.pop(metadata_field, None)
+            else:
+                new_widget[metadata_field] = metadata_value
 
         if existing_idx is not None:
             target_group["widgets"][existing_idx] = new_widget

--- a/src/niamoto/gui/api/routers/config.py
+++ b/src/niamoto/gui/api/routers/config.py
@@ -1475,8 +1475,8 @@ class ExportWidgetUpdate(BaseModel):
 
     plugin: str
     data_source: str
-    title: Optional[str] = None
-    description: Optional[str] = None
+    title: Optional[LocalizedString] = None
+    description: Optional[LocalizedString] = None
     params: Dict[str, Any] = {}
 
 
@@ -1755,16 +1755,26 @@ async def update_export_widget(
                 existing_idx = idx
                 break
 
-        new_widget = {
-            "plugin": update.plugin,
-            "data_source": (
-                "" if update.plugin == "hierarchical_nav_widget" else update.data_source
-            ),
-            "params": update.params,
-        }
-        if update.title:
+        new_widget: Dict[str, Any] = {}
+        if existing_idx is not None and isinstance(
+            target_group["widgets"][existing_idx], dict
+        ):
+            new_widget.update(target_group["widgets"][existing_idx])
+
+        new_widget.update(
+            {
+                "plugin": update.plugin,
+                "data_source": (
+                    ""
+                    if update.plugin == "hierarchical_nav_widget"
+                    else update.data_source
+                ),
+                "params": update.params,
+            }
+        )
+        if update.title is not None:
             new_widget["title"] = update.title
-        if update.description:
+        if update.description is not None:
             new_widget["description"] = update.description
 
         if existing_idx is not None:

--- a/src/niamoto/gui/api/routers/layout.py
+++ b/src/niamoto/gui/api/routers/layout.py
@@ -17,6 +17,7 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 from starlette.concurrency import run_in_threadpool
 
+from niamoto.common.i18n import LocalizedString
 from niamoto.gui.api.context import get_working_directory
 from niamoto.gui.api.services.preview_utils import (
     error_html,
@@ -38,8 +39,10 @@ class WidgetLayoutInfo(BaseModel):
 
     index: int = Field(..., description="Original index in export.yml")
     plugin: str = Field(..., description="Widget plugin name")
-    title: str = Field(..., description="Widget title")
-    description: Optional[str] = Field(None, description="Widget description")
+    title: LocalizedString = Field(..., description="Widget title")
+    description: Optional[LocalizedString] = Field(
+        None, description="Widget description"
+    )
     data_source: str = Field(..., description="Data source key")
     colspan: int = Field(default=1, ge=1, le=2, description="Column span (1 or 2)")
     order: int = Field(..., description="Display order")
@@ -52,7 +55,7 @@ class NavigationWidgetInfo(BaseModel):
     """Information about the navigation widget."""
 
     plugin: str = Field(default="hierarchical_nav_widget")
-    title: str
+    title: LocalizedString
     params: Dict[str, Any] = Field(default_factory=dict)
     is_hierarchical: bool = Field(default=False)
 
@@ -70,8 +73,8 @@ class WidgetLayoutUpdate(BaseModel):
     """Update for a single widget layout."""
 
     index: int = Field(..., description="Original widget index")
-    title: Optional[str] = Field(None, description="New title (if changed)")
-    description: Optional[str] = Field(None, description="New description")
+    title: Optional[LocalizedString] = Field(None, description="New title (if changed)")
+    description: Optional[LocalizedString] = Field(None, description="New description")
     colspan: Optional[int] = Field(None, ge=1, le=2, description="New colspan")
     order: int = Field(..., description="New display order")
 

--- a/src/niamoto/gui/api/services/preview_engine/engine.py
+++ b/src/niamoto/gui/api/services/preview_engine/engine.py
@@ -203,6 +203,7 @@ class PreviewEngine:
         self._db: Database | None = None
         self._rich_entity_cache: dict[str, Any] = {}
         self._group_ids_cache: dict[str, list[Any]] = {}
+        self._render_lock = threading.RLock()
 
         # Dispatch table for special widget types.
         # Each entry: (matcher, widget_plugin, handler)
@@ -270,7 +271,18 @@ class PreviewEngine:
     # ------------------------------------------------------------------
 
     def render(self, request: PreviewRequest) -> PreviewResult:
-        """Single entry point -- resolve, load, transform, render, wrap."""
+        """Single entry point -- resolve, load, transform, render, wrap.
+
+        Preview iframes are lazy-loaded by the browser and can request several
+        widgets at once while scrolling. DuckDB/duckdb-engine can raise duplicate
+        ATTACH errors when the shared preview engine opens connections to the
+        same database file concurrently, so render work is serialized here while
+        preserving frontend lazy loading.
+        """
+        with self._render_lock:
+            return self._render_locked(request)
+
+    def _render_locked(self, request: PreviewRequest) -> PreviewResult:
         warnings: list[str] = []
         template_id = request.template_id
 

--- a/src/niamoto/gui/api/services/templates/utils/class_object_rendering.py
+++ b/src/niamoto/gui/api/services/templates/utils/class_object_rendering.py
@@ -322,7 +322,7 @@ def _build_widget_params_for_configured(
             params.setdefault("x_axis", "labels")
             params.setdefault("y_axis", "counts")
             params.setdefault("orientation", "v")
-            params.setdefault("gradient_color", "#10b981")
+            params.setdefault("gradient_color", "#4f8068")
 
         # For series extractors — data is {"tops": [...], "counts": [...]}
         elif transformer in ("class_object_series_extractor", "series_extractor"):

--- a/src/niamoto/gui/api/services/templates/utils/widget_utils.py
+++ b/src/niamoto/gui/api/services/templates/utils/widget_utils.py
@@ -135,7 +135,7 @@ def generate_widget_params(
                 "orientation": "v",
                 "x_axis": "labels",
                 "y_axis": "counts",
-                "gradient_color": "#10b981",
+                "gradient_color": "#4f8068",
                 "gradient_mode": "luminance",
                 "show_legend": False,  # Hide legend - values shown on bars
             }
@@ -217,9 +217,9 @@ def generate_widget_params(
                     "source": "coordinates",
                     "type": "circle_markers",
                     "style": {
-                        "color": "#1fb99d",
+                        "color": "#5f8f82",
                         "weight": 1,
-                        "fillColor": "#00716b",
+                        "fillColor": "#4f8068",
                         "fillOpacity": 0.5,
                         "radius": 8,
                     },

--- a/src/niamoto/gui/ui/src/components/content/ContentRightPanel.tsx
+++ b/src/niamoto/gui/ui/src/components/content/ContentRightPanel.tsx
@@ -17,7 +17,6 @@ interface ContentRightPanelProps {
   availableFields?: string[]
   previewPreference: CollectionsPreviewPreference
   onPreviewPreferenceChange: (preference: CollectionsPreviewPreference) => void
-  hardwareConcurrency: number | null
   detailPreviewAutoRefresh: boolean
   onSelectWidget: (widget: ConfiguredWidget | null) => void
   onBack: () => void
@@ -33,7 +32,6 @@ export function ContentRightPanel({
   availableFields = [],
   previewPreference,
   onPreviewPreferenceChange,
-  hardwareConcurrency,
   detailPreviewAutoRefresh,
   onSelectWidget,
   onBack,
@@ -49,7 +47,6 @@ export function ContentRightPanel({
         groupBy={groupBy}
         previewPreference={previewPreference}
         onPreviewPreferenceChange={onPreviewPreferenceChange}
-        hardwareConcurrency={hardwareConcurrency}
         onSelectWidget={onSelectWidget}
         onLayoutSaved={onLayoutSaved}
       />

--- a/src/niamoto/gui/ui/src/components/content/ContentTab.tsx
+++ b/src/niamoto/gui/ui/src/components/content/ContentTab.tsx
@@ -35,7 +35,6 @@ import { ContentRightPanel } from './ContentRightPanel'
 import { AddWidgetModal } from '@/components/widgets/AddWidgetModal'
 import type { ReferenceInfo } from '@/hooks/useReferences'
 import {
-  getCollectionsHardwareConcurrency,
   readStoredCollectionsPreviewPreference,
   shouldAutoRefreshCollectionsDetailPreview,
   writeStoredCollectionsPreviewPreference,
@@ -78,7 +77,6 @@ export function ContentTab({ reference }: ContentTabProps) {
   const [previewPreference, setPreviewPreference] = useState<CollectionsPreviewPreference>(
     () => readStoredCollectionsPreviewPreference(),
   )
-  const hardwareConcurrency = useMemo(() => getCollectionsHardwareConcurrency(), [])
 
   const {
     loading: configuredWidgetsLoading,
@@ -123,13 +121,8 @@ export function ContentTab({ reference }: ContentTabProps) {
   }, [configuredWidgets, searchQuery])
 
   const detailPreviewAutoRefresh = useMemo(
-    () =>
-      shouldAutoRefreshCollectionsDetailPreview({
-        preference: previewPreference,
-        widgetCount: configuredWidgets.length,
-        hardwareConcurrency,
-      }),
-    [configuredWidgets.length, hardwareConcurrency, previewPreference],
+    () => shouldAutoRefreshCollectionsDetailPreview(previewPreference),
+    [previewPreference],
   )
 
   useDevListRenderMetric('collections.content.configuredWidgets', configuredWidgets.length, {
@@ -382,7 +375,6 @@ export function ContentTab({ reference }: ContentTabProps) {
                 availableFields={availableFields}
                 previewPreference={previewPreference}
                 onPreviewPreferenceChange={handlePreviewPreferenceChange}
-                hardwareConcurrency={hardwareConcurrency}
                 detailPreviewAutoRefresh={detailPreviewAutoRefresh}
                 onSelectWidget={handleSelectWidget}
                 onBack={handleBackToLayout}

--- a/src/niamoto/gui/ui/src/components/content/LayoutOverview.tsx
+++ b/src/niamoto/gui/ui/src/components/content/LayoutOverview.tsx
@@ -63,7 +63,10 @@ import {
 } from '@/components/ui/select'
 import type { ConfiguredWidget } from '@/components/widgets'
 import {
-  classifyCollectionsPerformanceTier,
+  resolveLocalizedString as resolveLocalizedStringValue,
+  type LocalizedString,
+} from '@/components/ui/localized-string'
+import {
   resolveCollectionsPreviewMode,
   type CollectionsPreviewPreference,
   type ResolvedCollectionsPreviewMode,
@@ -78,8 +81,8 @@ import { useDevListRenderMetric } from '@/shared/performance/devRenderMetrics'
 interface WidgetLayout {
   index: number
   plugin: string
-  title: string
-  description?: string
+  title: LocalizedString
+  description?: LocalizedString
   data_source: string
   colspan: 1 | 2
   order: number
@@ -88,7 +91,7 @@ interface WidgetLayout {
 
 interface NavigationWidgetInfo {
   plugin: string
-  title: string
+  title: LocalizedString
   params: Record<string, unknown>
   is_hierarchical: boolean
 }
@@ -102,8 +105,8 @@ interface LayoutResponse {
 
 interface WidgetLayoutUpdate {
   index: number
-  title?: string
-  description?: string
+  title?: LocalizedString
+  description?: LocalizedString
   colspan?: 1 | 2
   order: number
 }
@@ -172,7 +175,7 @@ function NavigationSidebar({
   navigationWidget,
   previewMode,
 }: NavigationSidebarProps) {
-  const { t } = useTranslation(['widgets', 'common'])
+  const { t, i18n } = useTranslation(['widgets', 'common'])
   const queryClient = useQueryClient()
 
   const referential = navigationWidget.params?.referential_data as string || groupBy
@@ -197,7 +200,7 @@ function NavigationSidebar({
           <List className="h-4 w-4 text-muted-foreground" />
         )}
         <span className="flex-1 font-medium text-sm truncate">
-          {navigationWidget.title}
+          {resolveLocalizedStringValue(navigationWidget.title, i18n.language)}
         </span>
         <Badge variant="outline" className="text-xs shrink-0">
           {navigationWidget.is_hierarchical ? t('layout.hierarchical') : t('layout.list')}
@@ -282,7 +285,7 @@ function SortableWidgetCard({
   onSelect,
   onPreviewFocus,
 }: SortableWidgetCardProps) {
-  const { t } = useTranslation(['widgets', 'common'])
+  const { t, i18n } = useTranslation(['widgets', 'common'])
 
   const descriptor: PreviewDescriptor = useMemo(() => ({
     templateId: widget.data_source,
@@ -307,6 +310,8 @@ function SortableWidgetCard({
 
   // Column span class
   const colSpanClass = widget.colspan === 1 ? 'col-span-6' : 'col-span-12'
+  const title = resolveLocalizedStringValue(widget.title, i18n.language)
+  const description = resolveLocalizedStringValue(widget.description, i18n.language)
 
   const shouldRenderPreview =
     !isDragging
@@ -340,7 +345,7 @@ function SortableWidgetCard({
         </button>
 
         {/* Title */}
-        <span className="flex-1 font-medium text-sm truncate">{widget.title}</span>
+        <span className="flex-1 font-medium text-sm truncate">{title}</span>
 
         {/* Plugin badge */}
         <Badge variant="secondary" className="text-[10px] shrink-0">
@@ -409,9 +414,9 @@ function SortableWidgetCard({
       </div>
 
       {/* Description footer */}
-      {widget.description && (
+      {description && (
         <div className="px-3 py-2 border-t bg-muted/30">
-          <p className="text-xs text-muted-foreground truncate">{widget.description}</p>
+          <p className="text-xs text-muted-foreground truncate">{description}</p>
         </div>
       )}
     </div>
@@ -424,7 +429,6 @@ interface LayoutOverviewProps {
   groupBy: string
   previewPreference: CollectionsPreviewPreference
   onPreviewPreferenceChange: (preference: CollectionsPreviewPreference) => void
-  hardwareConcurrency: number | null
   onSelectWidget: (widget: ConfiguredWidget) => void
   onLayoutSaved?: () => void
 }
@@ -434,11 +438,10 @@ export function LayoutOverview({
   groupBy,
   previewPreference,
   onPreviewPreferenceChange,
-  hardwareConcurrency,
   onSelectWidget,
   onLayoutSaved,
 }: LayoutOverviewProps) {
-  const { t } = useTranslation(['widgets', 'common'])
+  const { t, i18n } = useTranslation(['widgets', 'common'])
   const queryClient = useQueryClient()
 
   // Fetch layout data
@@ -450,16 +453,6 @@ export function LayoutOverview({
   } = useQuery({
     queryKey: ['layout', groupBy],
     queryFn: () => fetchLayout(groupBy),
-  })
-
-  // Fetch representative entities
-  const {
-    data: representatives,
-    error: representativesError,
-    refetch: refetchRepresentatives,
-  } = useQuery({
-    queryKey: ['representatives', groupBy],
-    queryFn: () => fetchRepresentatives(groupBy),
   })
 
   // Local state
@@ -497,29 +490,26 @@ export function LayoutOverview({
       ? layoutDraftState.hasChanges
       : false
 
-  const contentWidgetCount = useMemo(
-    () => localWidgets.filter((w) => !w.is_navigation).length,
-    [localWidgets],
-  )
-  const performanceTier = useMemo(
-    () =>
-      classifyCollectionsPerformanceTier({
-        widgetCount: contentWidgetCount,
-        hardwareConcurrency,
-      }),
-    [contentWidgetCount, hardwareConcurrency],
-  )
   const resolvedPreviewMode = useMemo(
     () =>
       resolveCollectionsPreviewMode({
         preference: previewPreference,
-        widgetCount: contentWidgetCount,
-        hardwareConcurrency,
         isDragging,
       }),
-    [contentWidgetCount, hardwareConcurrency, isDragging, previewPreference],
+    [isDragging, previewPreference],
   )
   const navigationPreviewMode = resolvedPreviewMode === 'thumbnail' ? 'thumbnail' : 'off'
+
+  // Fetch representative entities only when previews need a selected entity.
+  const {
+    data: representatives,
+    error: representativesError,
+    refetch: refetchRepresentatives,
+  } = useQuery({
+    queryKey: ['representatives', groupBy],
+    queryFn: () => fetchRepresentatives(groupBy),
+    enabled: resolvedPreviewMode !== 'off',
+  })
 
   const selectedEntityId = useMemo(() => {
     const explicitEntityId =
@@ -657,12 +647,15 @@ export function LayoutOverview({
   const handleSelectWidget = useCallback((layoutWidget: WidgetLayout) => {
     // Try to find matching ConfiguredWidget by data_source or title
     const configuredWidget = configuredWidgets.find(
-      (w) => w.dataSource === layoutWidget.data_source || w.title === layoutWidget.title
+      (w) =>
+        w.dataSource === layoutWidget.data_source ||
+        resolveLocalizedStringValue(w.title, i18n.language) ===
+          resolveLocalizedStringValue(layoutWidget.title, i18n.language)
     )
     if (configuredWidget) {
       onSelectWidget(configuredWidget)
     }
-  }, [configuredWidgets, onSelectWidget])
+  }, [configuredWidgets, i18n.language, onSelectWidget])
 
   const handlePreviewFocus = useCallback((cardId: string) => {
     setFocusedPreviewCardId((current) => current === cardId ? current : cardId)
@@ -689,7 +682,6 @@ export function LayoutOverview({
     detail: {
       activePreviewCount,
       groupBy,
-      performanceTier,
       previewMode: resolvedPreviewMode,
     },
   })
@@ -698,7 +690,6 @@ export function LayoutOverview({
     itemThreshold: 10,
     detail: {
       groupBy,
-      performanceTier,
       previewMode: resolvedPreviewMode,
       widgetCount: contentWidgets.length,
     },
@@ -708,13 +699,11 @@ export function LayoutOverview({
     const durationMs = measureCollectionsContentSwitch(groupBy, {
       widgetCount: contentWidgets.length,
       previewMode: resolvedPreviewMode,
-      performanceTier,
     })
     recordCollectionsPerf('collections.layout.state', {
       activePreviewCount,
       durationMs,
       groupBy,
-      performanceTier,
       previewMode: resolvedPreviewMode,
       widgetCount: contentWidgets.length,
     })
@@ -722,7 +711,6 @@ export function LayoutOverview({
     activePreviewCount,
     contentWidgets.length,
     groupBy,
-    performanceTier,
     resolvedPreviewMode,
   ])
 
@@ -800,18 +788,11 @@ export function LayoutOverview({
             <SelectValue placeholder={t('layout.previews')} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="auto">{t('layout.previewMode.auto')}</SelectItem>
             <SelectItem value="thumbnail">{t('layout.previewMode.thumbnail')}</SelectItem>
             <SelectItem value="focused">{t('layout.previewMode.focused')}</SelectItem>
             <SelectItem value="off">{t('layout.previewMode.off')}</SelectItem>
           </SelectContent>
         </Select>
-
-        {previewPreference === 'auto' && performanceTier === 'low' && (
-          <Badge variant="outline" className="text-xs">
-            {t('layout.performanceModeLow')}
-          </Badge>
-        )}
 
         {resolvedPreviewMode !== 'off' && representatives && representatives.entities.length > 0 && (
           <Select
@@ -841,7 +822,9 @@ export function LayoutOverview({
           className="h-8 w-8"
           onClick={() => {
             refetch()
-            void refetchRepresentatives()
+            if (resolvedPreviewMode !== 'off') {
+              void refetchRepresentatives()
+            }
             invalidateAllPreviews(queryClient)
           }}
           disabled={saveMutation.isPending}
@@ -936,7 +919,9 @@ export function LayoutOverview({
                     )}
                   >
                     <div className="flex items-center gap-2 px-3 py-2 bg-muted/50 border-b">
-                      <span className="font-medium text-sm">{activeWidget.title}</span>
+                      <span className="font-medium text-sm">
+                        {resolveLocalizedStringValue(activeWidget.title, i18n.language)}
+                      </span>
                     </div>
                     <div className="h-16 bg-muted/30 flex items-center justify-center text-muted-foreground text-sm">
                       {getPluginLabel(activeWidget.plugin)}

--- a/src/niamoto/gui/ui/src/components/content/WidgetDetailPanel.tsx
+++ b/src/niamoto/gui/ui/src/components/content/WidgetDetailPanel.tsx
@@ -101,6 +101,15 @@ function areWidgetDraftsEqual(
   return serializeWidgetDraft(a) === serializeWidgetDraft(b)
 }
 
+function getSavedWidgetDraft(widget: ConfiguredWidget): Partial<ConfiguredWidget> {
+  return {
+    title: widget.title,
+    description: widget.description,
+    transformerParams: widget.transformerParams,
+    widgetParams: widget.widgetParams,
+  }
+}
+
 interface WidgetDetailPanelProps {
   widget: ConfiguredWidget
   groupBy: string
@@ -217,6 +226,8 @@ export function WidgetDetailPanel({
     () => (autoRefreshPreview ? previewDraft : appliedPreviewDraft),
     [appliedPreviewDraft, autoRefreshPreview, previewDraft],
   )
+
+  const savedWidgetDraft = useMemo(() => getSavedWidgetDraft(widget), [widget])
 
   const previewTitle = useMemo(
     () => resolveLocalizedString(
@@ -341,17 +352,19 @@ export function WidgetDetailPanel({
   }, [onDelete, onBack])
 
   const handlePreviewDraftChange = useCallback((config: Partial<ConfiguredWidget>) => {
+    const normalizedConfig = areWidgetDraftsEqual(config, savedWidgetDraft) ? null : config
+
     updatePanelState((prev) => {
-      if (areWidgetDraftsEqual(prev.previewDraft, config)) {
+      if (areWidgetDraftsEqual(prev.previewDraft, normalizedConfig)) {
         return prev
       }
 
       return {
         ...prev,
-        previewDraft: config,
+        previewDraft: normalizedConfig,
       }
     })
-  }, [updatePanelState])
+  }, [savedWidgetDraft, updatePanelState])
 
   return (
     <div className="h-full flex flex-col">

--- a/src/niamoto/gui/ui/src/components/content/WidgetListPanel.tsx
+++ b/src/niamoto/gui/ui/src/components/content/WidgetListPanel.tsx
@@ -8,7 +8,7 @@
  * - Simplified item display (no inline expansion)
  */
 import { useState, useCallback, useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import {
   DndContext,
   closestCenter,
@@ -44,7 +44,7 @@ import {
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import type { LocalizedString } from '@/components/ui/localized-input'
+import { resolveLocalizedString } from '@/components/ui/localized-string'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -91,13 +91,6 @@ const CATEGORY_COLORS: Record<string, { text: string; bg: string; border: string
   table: { text: 'text-slate-600', bg: 'bg-slate-50', border: 'border-slate-200' },
 }
 
-// Helper to resolve LocalizedString for display
-function resolveLocalizedString(value: LocalizedString | undefined, defaultLang = 'fr'): string {
-  if (!value) return ''
-  if (typeof value === 'string') return value
-  return value[defaultLang] || Object.values(value)[0] || ''
-}
-
 interface SortableWidgetItemProps {
   widget: ConfiguredWidget
   isSelected: boolean
@@ -113,7 +106,7 @@ function SortableWidgetItem({
   onDeleteClick,
   onDuplicateClick,
 }: SortableWidgetItemProps) {
-  const { t } = useTranslation(['widgets', 'common'])
+  const { t, i18n } = useTranslation(['widgets', 'common'])
   const {
     attributes,
     listeners,
@@ -166,7 +159,9 @@ function SortableWidgetItem({
 
       {/* Widget info */}
       <div className="flex-1 min-w-0">
-        <div className="font-medium text-xs truncate">{resolveLocalizedString(widget.title)}</div>
+        <div className="font-medium text-xs truncate">
+          {resolveLocalizedString(widget.title, i18n.language)}
+        </div>
         <div className="text-[10px] text-muted-foreground truncate">
           {getPluginLabel(widget.widgetPlugin)}
         </div>
@@ -218,7 +213,7 @@ export function WidgetListPanel({
   onDuplicate,
   onReorder,
 }: WidgetListPanelProps) {
-  const { t } = useTranslation(['widgets', 'common'])
+  const { t, i18n } = useTranslation(['widgets', 'common'])
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false)
   const [targetWidget, setTargetWidget] = useState<ConfiguredWidget | null>(null)
@@ -374,11 +369,14 @@ export function WidgetListPanel({
               <AlertTriangle className="h-5 w-5 text-destructive" />
               {t('listPanel.deleteWidget')}
             </AlertDialogTitle>
-            <AlertDialogDescription
-              dangerouslySetInnerHTML={{
-                __html: t('listPanel.deleteDescription', { title: targetWidget?.title })
-              }}
-            />
+            <AlertDialogDescription>
+              <Trans
+                i18nKey="listPanel.deleteDescription"
+                t={t}
+                values={{ title: resolveLocalizedString(targetWidget?.title, i18n.language) }}
+                components={{ strong: <strong /> }}
+              />
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isDeleting}>{t('common:actions.cancel')}</AlertDialogCancel>
@@ -406,7 +404,9 @@ export function WidgetListPanel({
           <DialogHeader>
             <DialogTitle>{t('listPanel.duplicateWidget')}</DialogTitle>
             <DialogDescription>
-              {t('listPanel.duplicateDescription', { title: targetWidget?.title })}
+              {t('listPanel.duplicateDescription', {
+                title: resolveLocalizedString(targetWidget?.title, i18n.language),
+              })}
             </DialogDescription>
           </DialogHeader>
           <div className="py-4">

--- a/src/niamoto/gui/ui/src/components/content/previewPolicy.test.ts
+++ b/src/niamoto/gui/ui/src/components/content/previewPolicy.test.ts
@@ -1,12 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
-  classifyCollectionsPerformanceTier,
-  getCollectionsHardwareConcurrency,
   normalizeCollectionsPreviewPreference,
   readStoredCollectionsPreviewPreference,
   resolveCollectionsPreviewMode,
-  resolveDefaultCollectionsPreviewMode,
   shouldAutoRefreshCollectionsDetailPreview,
   writeStoredCollectionsPreviewPreference,
 } from './previewPolicy'
@@ -16,85 +13,45 @@ describe('previewPolicy', () => {
     expect(normalizeCollectionsPreviewPreference('off')).toBe('off')
     expect(normalizeCollectionsPreviewPreference('focused')).toBe('focused')
     expect(normalizeCollectionsPreviewPreference('thumbnail')).toBe('thumbnail')
-    expect(normalizeCollectionsPreviewPreference('weird')).toBe('auto')
-    expect(normalizeCollectionsPreviewPreference(null)).toBe('auto')
-  })
-
-  it('classifies low-power contexts conservatively', () => {
-    expect(
-      classifyCollectionsPerformanceTier({
-        widgetCount: 6,
-        hardwareConcurrency: 4,
-      }),
-    ).toBe('low')
-    expect(
-      classifyCollectionsPerformanceTier({
-        widgetCount: 10,
-        hardwareConcurrency: 6,
-      }),
-    ).toBe('low')
-    expect(
-      classifyCollectionsPerformanceTier({
-        widgetCount: 18,
-        hardwareConcurrency: 12,
-      }),
-    ).toBe('low')
-  })
-
-  it('defaults to thumbnail only when the context is light enough', () => {
-    expect(
-      resolveDefaultCollectionsPreviewMode({
-        widgetCount: 4,
-        hardwareConcurrency: 8,
-      }),
-    ).toBe('thumbnail')
-    expect(
-      resolveDefaultCollectionsPreviewMode({
-        widgetCount: 12,
-        hardwareConcurrency: 8,
-      }),
-    ).toBe('focused')
-    expect(
-      resolveDefaultCollectionsPreviewMode({
-        widgetCount: 8,
-        hardwareConcurrency: 4,
-      }),
-    ).toBe('focused')
+    expect(normalizeCollectionsPreviewPreference('auto')).toBe('focused')
+    expect(normalizeCollectionsPreviewPreference('weird')).toBe('focused')
+    expect(normalizeCollectionsPreviewPreference(null)).toBe('focused')
   })
 
   it('forces previews off during drag operations', () => {
     expect(
       resolveCollectionsPreviewMode({
         preference: 'thumbnail',
-        widgetCount: 5,
-        hardwareConcurrency: 8,
         isDragging: true,
       }),
     ).toBe('off')
   })
 
-  it('disables detail auto-refresh in conservative modes', () => {
+  it('uses the explicit preference when not dragging', () => {
     expect(
-      shouldAutoRefreshCollectionsDetailPreview({
-        preference: 'auto',
-        widgetCount: 12,
-        hardwareConcurrency: 4,
+      resolveCollectionsPreviewMode({
+        preference: 'focused',
+        isDragging: false,
       }),
-    ).toBe(false)
+    ).toBe('focused')
     expect(
-      shouldAutoRefreshCollectionsDetailPreview({
+      resolveCollectionsPreviewMode({
         preference: 'thumbnail',
-        widgetCount: 5,
-        hardwareConcurrency: 8,
+        isDragging: false,
       }),
-    ).toBe(true)
+    ).toBe('thumbnail')
+  })
+
+  it('auto-refreshes detail previews only when thumbnails are enabled', () => {
+    expect(shouldAutoRefreshCollectionsDetailPreview('off')).toBe(false)
+    expect(shouldAutoRefreshCollectionsDetailPreview('focused')).toBe(false)
+    expect(shouldAutoRefreshCollectionsDetailPreview('thumbnail')).toBe(true)
   })
 
   it('reads and writes the stored preference', () => {
     const storage = {
       getItem: vi.fn().mockReturnValue('focused'),
       setItem: vi.fn(),
-      removeItem: vi.fn(),
     }
 
     expect(readStoredCollectionsPreviewPreference(storage)).toBe('focused')
@@ -104,18 +61,5 @@ describe('previewPolicy', () => {
       'niamoto.collectionsPreviewPreference',
       'thumbnail',
     )
-
-    writeStoredCollectionsPreviewPreference('auto', storage)
-    expect(storage.removeItem).toHaveBeenCalledWith(
-      'niamoto.collectionsPreviewPreference',
-    )
-  })
-
-  it('normalizes hardware concurrency safely', () => {
-    expect(getCollectionsHardwareConcurrency({ hardwareConcurrency: 4 })).toBe(4)
-    expect(getCollectionsHardwareConcurrency({ hardwareConcurrency: 0 })).toBeNull()
-    expect(
-      getCollectionsHardwareConcurrency({} as Pick<Navigator, 'hardwareConcurrency'>),
-    ).toBeNull()
   })
 })

--- a/src/niamoto/gui/ui/src/components/content/previewPolicy.ts
+++ b/src/niamoto/gui/ui/src/components/content/previewPolicy.ts
@@ -1,13 +1,8 @@
-export type CollectionsPreviewPreference = 'auto' | 'off' | 'focused' | 'thumbnail'
 export type ResolvedCollectionsPreviewMode = 'off' | 'focused' | 'thumbnail'
-export type CollectionsPerformanceTier = 'low' | 'standard'
+export type CollectionsPreviewPreference = ResolvedCollectionsPreviewMode
 
 const PREVIEW_PREFERENCE_STORAGE_KEY = 'niamoto.collectionsPreviewPreference'
-
-export interface CollectionsPreviewContext {
-  widgetCount: number
-  hardwareConcurrency?: number | null
-}
+const DEFAULT_PREVIEW_PREFERENCE: CollectionsPreviewPreference = 'focused'
 
 export function normalizeCollectionsPreviewPreference(
   value?: string | null,
@@ -16,69 +11,16 @@ export function normalizeCollectionsPreviewPreference(
     case 'off':
     case 'focused':
     case 'thumbnail':
-    case 'auto':
       return value
     default:
-      return 'auto'
+      return DEFAULT_PREVIEW_PREFERENCE
   }
-}
-
-export function getCollectionsHardwareConcurrency(
-  nav: Pick<Navigator, 'hardwareConcurrency'> | undefined = typeof navigator !== 'undefined'
-    ? navigator
-    : undefined,
-): number | null {
-  const value = nav?.hardwareConcurrency
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return null
-  }
-
-  return Math.round(value)
-}
-
-export function classifyCollectionsPerformanceTier({
-  widgetCount,
-  hardwareConcurrency,
-}: CollectionsPreviewContext): CollectionsPerformanceTier {
-  const cpu = hardwareConcurrency ?? null
-
-  if (cpu !== null && cpu <= 4) {
-    return 'low'
-  }
-
-  if (cpu !== null && cpu <= 6 && widgetCount >= 8) {
-    return 'low'
-  }
-
-  if (widgetCount >= 18) {
-    return 'low'
-  }
-
-  return 'standard'
-}
-
-export function resolveDefaultCollectionsPreviewMode(
-  context: CollectionsPreviewContext,
-): ResolvedCollectionsPreviewMode {
-  const tier = classifyCollectionsPerformanceTier(context)
-
-  if (tier === 'low') {
-    return 'focused'
-  }
-
-  if (context.widgetCount >= 12) {
-    return 'focused'
-  }
-
-  return 'thumbnail'
 }
 
 export function resolveCollectionsPreviewMode({
   preference,
-  widgetCount,
-  hardwareConcurrency,
   isDragging,
-}: CollectionsPreviewContext & {
+}: {
   preference: CollectionsPreviewPreference
   isDragging?: boolean
 }): ResolvedCollectionsPreviewMode {
@@ -86,31 +28,13 @@ export function resolveCollectionsPreviewMode({
     return 'off'
   }
 
-  if (preference === 'auto') {
-    return resolveDefaultCollectionsPreviewMode({
-      widgetCount,
-      hardwareConcurrency,
-    })
-  }
-
   return preference
 }
 
 export function shouldAutoRefreshCollectionsDetailPreview(
-  context: CollectionsPreviewContext & {
-    preference: CollectionsPreviewPreference
-  },
+  preference: CollectionsPreviewPreference,
 ): boolean {
-  const resolvedMode = resolveCollectionsPreviewMode({
-    ...context,
-    isDragging: false,
-  })
-
-  if (resolvedMode === 'off' || resolvedMode === 'focused') {
-    return false
-  }
-
-  return classifyCollectionsPerformanceTier(context) === 'standard'
+  return preference === 'thumbnail'
 }
 
 export function readStoredCollectionsPreviewPreference(
@@ -125,16 +49,11 @@ export function readStoredCollectionsPreviewPreference(
 
 export function writeStoredCollectionsPreviewPreference(
   preference: CollectionsPreviewPreference,
-  storage: Pick<Storage, 'setItem' | 'removeItem'> | undefined = typeof window !== 'undefined'
+  storage: Pick<Storage, 'setItem'> | undefined = typeof window !== 'undefined'
     ? window.localStorage
     : undefined,
 ): void {
   if (!storage) {
-    return
-  }
-
-  if (preference === 'auto') {
-    storage.removeItem(PREVIEW_PREFERENCE_STORAGE_KEY)
     return
   }
 

--- a/src/niamoto/gui/ui/src/components/forms/JsonSchemaForm.test.tsx
+++ b/src/niamoto/gui/ui/src/components/forms/JsonSchemaForm.test.tsx
@@ -6,6 +6,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import JsonSchemaForm from './JsonSchemaForm'
 
+interface MockSelectOption {
+  value: string | number | boolean
+  label: string
+}
+
+interface MockSelectFieldProps {
+  name: string
+  value?: string | number | boolean
+  onChange?: (value: string | number | boolean | undefined) => void
+  options: MockSelectOption[]
+}
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
@@ -14,6 +26,28 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@/lib/api/recipes', () => ({
   useSourceColumns: () => ({ columns: [] }),
+}))
+
+vi.mock('./fields/SelectField', () => ({
+  default: ({ name, value, onChange, options }: MockSelectFieldProps) => (
+    <select
+      data-testid={name}
+      value={value?.toString() ?? ''}
+      onChange={(event) => {
+        const option = options.find(
+          (selectOption) => selectOption.value.toString() === event.target.value
+        )
+        onChange?.(option?.value)
+      }}
+    >
+      <option value="">Select</option>
+      {options.map((option) => (
+        <option key={option.value.toString()} value={option.value.toString()}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
 }))
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
@@ -36,7 +70,10 @@ describe('JsonSchemaForm', () => {
                 type: 'string',
                 title: 'Transform',
                 'ui:widget': 'select',
-                'ui:options': [{ value: 'known_transform', label: 'Known transform' }],
+                'ui:options': [
+                  { value: 'known_transform', label: 'Known transform' },
+                  { value: 'other_transform', label: 'Other transform' },
+                ],
               },
               transform_params: {
                 type: 'object',
@@ -46,6 +83,9 @@ describe('JsonSchemaForm', () => {
                 'ui:transform_schemas': {
                   known_transform: {
                     x_field: { type: 'string', default: 'x' },
+                  },
+                  other_transform: {
+                    y_field: { type: 'string', default: 'y' },
                   },
                 },
               },
@@ -104,5 +144,38 @@ describe('JsonSchemaForm', () => {
     expect(textarea?.value).toContain('"x_field": "class_name"')
     expect(textarea?.value).toContain('"y_field": "value"')
     expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('resets transform params when the selected transform changes', async () => {
+    const onChange = vi.fn()
+
+    await render(
+      <JsonSchemaForm
+        pluginId="bar_plot"
+        showTitle={false}
+        initialValues={{
+          transform: 'known_transform',
+          transform_params: {
+            x_field: 'class_name',
+            stale_field: 'stale',
+          },
+        }}
+        onChange={onChange}
+      />,
+    )
+
+    const select = container?.querySelector('[data-testid="transform"]') as HTMLSelectElement
+
+    act(() => {
+      select.value = 'other_transform'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      transform: 'other_transform',
+      transform_params: {
+        y_field: 'y',
+      },
+    })
   })
 })

--- a/src/niamoto/gui/ui/src/components/forms/JsonSchemaForm.test.tsx
+++ b/src/niamoto/gui/ui/src/components/forms/JsonSchemaForm.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import JsonSchemaForm from './JsonSchemaForm'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}))
+
+vi.mock('@/lib/api/recipes', () => ({
+  useSourceColumns: () => ({ columns: [] }),
+}))
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+describe('JsonSchemaForm', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          plugin_type: 'widget',
+          has_params: true,
+          schema: {
+            properties: {
+              transform: {
+                type: 'string',
+                title: 'Transform',
+                'ui:widget': 'select',
+                'ui:options': [{ value: 'known_transform', label: 'Known transform' }],
+              },
+              transform_params: {
+                type: 'object',
+                title: 'Transform params',
+                'ui:widget': 'json',
+                'ui:condition': 'transform',
+                'ui:transform_schemas': {
+                  known_transform: {
+                    x_field: { type: 'string', default: 'x' },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      }),
+    )
+  })
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+    }
+    container?.remove()
+    root = null
+    container = null
+    vi.unstubAllGlobals()
+  })
+
+  async function render(ui: ReactNode) {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(ui)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+
+  it('falls back to raw JSON editing when transform params have no dedicated schema', async () => {
+    const onChange = vi.fn()
+
+    await render(
+      <JsonSchemaForm
+        pluginId="bar_plot"
+        showTitle={false}
+        initialValues={{
+          transform: 'custom_transform',
+          transform_params: {
+            x_field: 'class_name',
+            y_field: 'value',
+          },
+        }}
+        onChange={onChange}
+      />,
+    )
+
+    const textarea = container?.querySelector('textarea')
+
+    expect(textarea?.value).toContain('"x_field": "class_name"')
+    expect(textarea?.value).toContain('"y_field": "value"')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/niamoto/gui/ui/src/components/forms/JsonSchemaForm.tsx
+++ b/src/niamoto/gui/ui/src/components/forms/JsonSchemaForm.tsx
@@ -44,6 +44,14 @@ import {
   isStringArray,
 } from './formSchemaTypes';
 
+interface TransformParamDef {
+  type: string;
+  default?: FormValue;
+  description?: string;
+}
+
+type TransformSchemas = Record<string, Record<string, TransformParamDef>>;
+
 interface JsonSchemaFormProps {
   pluginId: string;
   pluginType?: string;
@@ -150,6 +158,12 @@ function serializeFormValue(value: unknown): string {
 
 function areFormValuesEqual(a: unknown, b: unknown): boolean {
   return serializeFormValue(a) === serializeFormValue(b);
+}
+
+function hasMeaningfulParamsValue(params: FormValues): boolean {
+  return Object.values(params).some(
+    (paramValue) => paramValue !== undefined && paramValue !== ''
+  );
 }
 
 const JsonSchemaForm: React.FC<JsonSchemaFormProps> = ({
@@ -298,6 +312,40 @@ const JsonSchemaForm: React.FC<JsonSchemaFormProps> = ({
     });
   }, [t]);
 
+  const resolveParamsForTransform = React.useCallback((transformValue: FormValue | undefined): FormValue | undefined => {
+    if (typeof transformValue !== 'string') {
+      return undefined;
+    }
+
+    const transformParamsField = schema?.schema?.properties?.transform_params;
+    if (!transformParamsField) {
+      return undefined;
+    }
+
+    const transformSchemas = getUiSchemaValue<TransformSchemas>(
+      transformParamsField,
+      'ui:transform_schemas'
+    );
+    const transformSchema = transformSchemas?.[transformValue];
+    if (!transformSchema) {
+      return undefined;
+    }
+
+    const previousParams = isFormValues(formData.transform_params)
+      ? formData.transform_params
+      : {};
+    const nextParams: FormValues = {};
+    Object.entries(transformSchema).forEach(([key, def]) => {
+      if (previousParams[key] !== undefined) {
+        nextParams[key] = previousParams[key];
+      } else if (def.default !== undefined) {
+        nextParams[key] = def.default;
+      }
+    });
+
+    return hasMeaningfulParamsValue(nextParams) ? nextParams : undefined;
+  }, [formData.transform_params, schema]);
+
   // Handle field changes
   const handleFieldChange = React.useCallback((fieldName: string, value: FormValue | undefined) => {
     if (areFormValuesEqual(formData[fieldName], value)) {
@@ -305,6 +353,13 @@ const JsonSchemaForm: React.FC<JsonSchemaFormProps> = ({
     }
 
     const newData = { ...formData, [fieldName]: value };
+    let nextTransformParams: FormValue | undefined;
+
+    if (fieldName === 'transform') {
+      nextTransformParams = resolveParamsForTransform(value);
+      newData.transform_params = nextTransformParams;
+    }
+
     setFormData(newData);
     lastSyncedValuesRef.current = JSON.stringify(filterHiddenValues(newData));
 
@@ -314,8 +369,11 @@ const JsonSchemaForm: React.FC<JsonSchemaFormProps> = ({
 
     if (form) {
       form.setValue(fieldName as never, value as never);
+      if (fieldName === 'transform') {
+        form.setValue('transform_params' as never, nextTransformParams as never);
+      }
     }
-  }, [filterHiddenValues, form, formData, onChange]);
+  }, [filterHiddenValues, form, formData, onChange, resolveParamsForTransform]);
 
   // Helper function to resolve $ref in schema
   const resolveRef = React.useCallback((ref: string): FieldSchema | null => {

--- a/src/niamoto/gui/ui/src/components/forms/JsonSchemaForm.tsx
+++ b/src/niamoto/gui/ui/src/components/forms/JsonSchemaForm.tsx
@@ -615,14 +615,15 @@ const JsonSchemaForm: React.FC<JsonSchemaFormProps> = ({
               resolvedFieldSchema,
               'ui:transform_schemas'
             );
-            if (transformSchemas) {
+            const selectedTransform = typeof formData.transform === 'string' ? formData.transform : undefined;
+            if (selectedTransform && transformSchemas?.[selectedTransform]) {
               return (
                 <TransformParamsField
                   key={fieldName}
                   {...commonProps}
                   value={isFormValues(fieldValue) ? fieldValue : undefined}
                   onChange={(value) => handleFieldChange(fieldName, value as unknown as FormValue)}
-                  selectedTransform={typeof formData.transform === 'string' ? formData.transform : undefined}
+                  selectedTransform={selectedTransform}
                   transformSchemas={transformSchemas}
                 />
               );

--- a/src/niamoto/gui/ui/src/components/forms/fields/TransformParamsField.test.tsx
+++ b/src/niamoto/gui/ui/src/components/forms/fields/TransformParamsField.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import TransformParamsField from './TransformParamsField'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}))
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+describe('TransformParamsField', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+    }
+    container?.remove()
+    root = null
+    container = null
+  })
+
+  function render(ui: ReactNode) {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(ui)
+    })
+  }
+
+  function setInputValue(input: HTMLInputElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+    setter?.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  it('does not emit params on initial mount', () => {
+    const onChange = vi.fn()
+
+    render(
+      <TransformParamsField
+        name="transform_params"
+        selectedTransform="bins_to_df"
+        transformSchemas={{
+          bins_to_df: {
+            bin_field: { type: 'string', default: 'bins' },
+            count_field: { type: 'string', default: 'counts' },
+          },
+        }}
+        value={{ bin_field: 'bins', percentage_field: 'percentages' }}
+        onChange={onChange}
+      />,
+    )
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('preserves existing params outside the schema when a field changes', () => {
+    const onChange = vi.fn()
+
+    render(
+      <TransformParamsField
+        name="transform_params"
+        selectedTransform="bins_to_df"
+        transformSchemas={{
+          bins_to_df: {
+            bin_field: { type: 'string', default: 'bins' },
+            count_field: { type: 'string', default: 'counts' },
+          },
+        }}
+        value={{ bin_field: 'bins', count_field: 'counts', percentage_field: 'percentages' }}
+        onChange={onChange}
+      />,
+    )
+
+    const inputs = container?.querySelectorAll('input')
+    expect(inputs?.length).toBe(2)
+
+    act(() => {
+      setInputValue(inputs?.[1] as HTMLInputElement, 'total')
+    })
+
+    expect(onChange).toHaveBeenCalledWith({
+      bin_field: 'bins',
+      count_field: 'total',
+      percentage_field: 'percentages',
+    })
+  })
+})

--- a/src/niamoto/gui/ui/src/components/forms/fields/TransformParamsField.tsx
+++ b/src/niamoto/gui/ui/src/components/forms/fields/TransformParamsField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -26,6 +26,12 @@ interface TransformParamsFieldProps {
   transformSchemas?: Record<string, Record<string, TransformParamDef>>
 }
 
+function hasMeaningfulValue(params: Record<string, unknown>): boolean {
+  return Object.values(params).some(
+    (paramValue) => paramValue !== undefined && paramValue !== ''
+  )
+}
+
 export default function TransformParamsField({
   name: _name,
   label,
@@ -45,14 +51,12 @@ export default function TransformParamsField({
     : null
   const resolvedParams = useMemo<Record<string, unknown>>(() => {
     if (!currentSchema) {
-      return {}
+      return value ? { ...value } : {}
     }
 
-    const nextParams: Record<string, unknown> = {}
+    const nextParams: Record<string, unknown> = value ? { ...value } : {}
     Object.entries(currentSchema).forEach(([key, def]) => {
-      if (value?.[key] !== undefined) {
-        nextParams[key] = value[key]
-      } else if (def.default !== undefined) {
+      if (nextParams[key] === undefined && def.default !== undefined) {
         nextParams[key] = def.default
       }
     })
@@ -67,23 +71,18 @@ export default function TransformParamsField({
     sourceKey,
     params: resolvedParams,
   }))
-  const lastEmittedValueRef = useRef('')
   const localParams = localState.sourceKey === sourceKey ? localState.params : resolvedParams
 
-  useEffect(() => {
-    const hasValues = Object.values(localParams).some(
-      (paramValue) => paramValue !== undefined && paramValue !== ''
-    )
-    const nextValue = hasValues ? localParams : undefined
-    const nextKey = JSON.stringify(nextValue ?? null)
-
-    if (nextKey === lastEmittedValueRef.current) {
-      return
-    }
-
-    lastEmittedValueRef.current = nextKey
-    onChange?.(nextValue)
-  }, [localParams, onChange])
+  const updateParams = useCallback(
+    (nextParams: Record<string, unknown>) => {
+      setLocalState({
+        sourceKey,
+        params: nextParams,
+      })
+      onChange?.(hasMeaningfulValue(nextParams) ? nextParams : undefined)
+    },
+    [onChange, sourceKey]
+  )
 
   if (!selectedTransform || !currentSchema) {
     return null
@@ -114,10 +113,7 @@ export default function TransformParamsField({
                 <Switch
                   checked={Boolean(localParams[key] ?? def.default)}
                   onCheckedChange={(checked) =>
-                    setLocalState({
-                      sourceKey,
-                      params: { ...localParams, [key]: checked },
-                    })
+                    updateParams({ ...localParams, [key]: checked })
                   }
                   disabled={disabled}
                 />
@@ -133,12 +129,9 @@ export default function TransformParamsField({
                     .split(',')
                     .map((item) => item.trim())
                     .filter(Boolean)
-                  setLocalState({
-                    sourceKey,
-                    params: {
-                      ...localParams,
-                      [key]: vals.length > 0 ? vals : undefined,
-                    },
+                  updateParams({
+                    ...localParams,
+                    [key]: vals.length > 0 ? vals : undefined,
                   })
                 }}
                 placeholder={t('widgets:form.commaSeparatedValues')}
@@ -150,12 +143,9 @@ export default function TransformParamsField({
                 className="h-8"
                 value={String(localParams[key] ?? def.default ?? '')}
                 onChange={(e) =>
-                  setLocalState({
-                    sourceKey,
-                    params: {
-                      ...localParams,
-                      [key]: e.target.value ? Number(e.target.value) : undefined,
-                    },
+                  updateParams({
+                    ...localParams,
+                    [key]: e.target.value ? Number(e.target.value) : undefined,
                   })
                 }
                 disabled={disabled}
@@ -165,12 +155,9 @@ export default function TransformParamsField({
                 className="h-8"
                 value={String(localParams[key] ?? def.default ?? '')}
                 onChange={(e) =>
-                  setLocalState({
-                    sourceKey,
-                    params: {
-                      ...localParams,
-                      [key]: e.target.value || undefined,
-                    },
+                  updateParams({
+                    ...localParams,
+                    [key]: e.target.value || undefined,
                   })
                 }
                 placeholder={def.default ? String(def.default) : undefined}

--- a/src/niamoto/gui/ui/src/components/widgets/WidgetConfigForm.test.tsx
+++ b/src/niamoto/gui/ui/src/components/widgets/WidgetConfigForm.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ConfiguredWidget } from './useWidgetConfig'
+import { WidgetConfigForm } from './WidgetConfigForm'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+vi.mock('@/components/forms/JsonSchemaForm', () => ({
+  default: ({ onChange }: { onChange?: (data: Record<string, unknown>) => void }) => (
+    <button
+      type="button"
+      data-testid="json-schema-change"
+      onClick={() => onChange?.({ color: 'blue' })}
+    >
+      JSON change
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/localized-input', () => ({
+  LocalizedInput: ({
+    label,
+    value,
+    onChange,
+  }: {
+    label?: string
+    value?: string | Record<string, string>
+    onChange: (value: string | undefined) => void
+  }) => (
+    <div>
+      <input
+        aria-label={label}
+        value={typeof value === 'string' ? value : value?.fr ?? ''}
+        readOnly
+      />
+      <button
+        type="button"
+        data-testid={`change-${label}`}
+        onClick={() => onChange('Richesse modifiée')}
+      >
+        Modifier
+      </button>
+    </div>
+  ),
+}))
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const baseWidget: ConfiguredWidget = {
+  id: 'richness',
+  transformerPlugin: 'field_aggregator',
+  widgetPlugin: 'bar_plot',
+  title: 'Richesse',
+  description: "Nombre d'espèces",
+  dataSource: 'richness',
+  transformerParams: { field: 'id' },
+  widgetParams: { color: 'green' },
+  category: 'chart',
+  hasTransformConfig: true,
+}
+
+describe('WidgetConfigForm', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+    }
+    container?.remove()
+    root = null
+    container = null
+    vi.useRealTimers()
+  })
+
+  function render(ui: ReactNode) {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(ui)
+    })
+  }
+
+  it('does not emit a live preview draft on initial mount', async () => {
+    vi.useFakeTimers()
+    const onChange = vi.fn()
+
+    render(
+      <WidgetConfigForm
+        widget={baseWidget}
+        groupBy="taxons"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        onChange={onChange}
+      />,
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(400)
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('emits a live preview draft after a user edit', async () => {
+    vi.useFakeTimers()
+    const onChange = vi.fn()
+
+    render(
+      <WidgetConfigForm
+        widget={baseWidget}
+        groupBy="taxons"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        onChange={onChange}
+      />,
+    )
+
+    act(() => {
+      container
+        ?.querySelector<HTMLButtonElement>('[data-testid="change-Titre"]')
+        ?.click()
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(400)
+    })
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Richesse modifiée',
+        transformerParams: baseWidget.transformerParams,
+        widgetParams: baseWidget.widgetParams,
+      }),
+    )
+  })
+})

--- a/src/niamoto/gui/ui/src/components/widgets/WidgetConfigForm.tsx
+++ b/src/niamoto/gui/ui/src/components/widgets/WidgetConfigForm.tsx
@@ -96,17 +96,23 @@ export function WidgetConfigForm({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Debounce ref for onChange
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hasUserEditedRef = useRef(false)
+
   // Reset state when widget changes
   useEffect(() => {
+    hasUserEditedRef.current = false
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
     setTitle(widget.title as LocalizedString | undefined)
     setDescription((widget.description as LocalizedString | undefined) || undefined)
     setTransformerParams(widget.transformerParams)
     setWidgetParams(widget.widgetParams)
     setError(null)
   }, [widget.description, widget.id, widget.title, widget.transformerParams, widget.widgetParams])
-
-  // Debounce ref for onChange
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Build current config from state
   const currentConfig = useMemo(() => ({
@@ -118,7 +124,7 @@ export function WidgetConfigForm({
 
   // Debounced onChange handler
   useEffect(() => {
-    if (!onChange) return
+    if (!onChange || !hasUserEditedRef.current) return
 
     if (debounceRef.current) {
       clearTimeout(debounceRef.current)
@@ -135,22 +141,66 @@ export function WidgetConfigForm({
     }
   }, [currentConfig, onChange])
 
+  const markUserEditIfChanged = useCallback((previous: unknown, next: unknown) => {
+    if (serializeConfigPart(previous) !== serializeConfigPart(next)) {
+      hasUserEditedRef.current = true
+    }
+  }, [])
+
+  const handleTitleChange = useCallback((value: LocalizedString | undefined) => {
+    setTitle((previous) => {
+      markUserEditIfChanged(previous, value)
+      return value
+    })
+  }, [markUserEditIfChanged])
+
+  const handleDescriptionChange = useCallback((value: LocalizedString | undefined) => {
+    setDescription((previous) => {
+      markUserEditIfChanged(previous, value)
+      return value
+    })
+  }, [markUserEditIfChanged])
+
   // Handle transformer params change
   const handleTransformerChange = useCallback((data: Record<string, unknown>) => {
-    setTransformerParams(prev => mergeConfigPart(prev, data))
+    setTransformerParams((prev) => {
+      const next = mergeConfigPart(prev, data)
+      if (next !== prev) {
+        hasUserEditedRef.current = true
+      }
+      return next
+    })
   }, [])
 
   // Handle widget params change
   const handleWidgetChange = useCallback((data: Record<string, unknown>) => {
-    setWidgetParams(prev => mergeConfigPart(prev, data))
+    setWidgetParams((prev) => {
+      const next = mergeConfigPart(prev, data)
+      if (next !== prev) {
+        hasUserEditedRef.current = true
+      }
+      return next
+    })
   }, [])
 
   const handleTransformerReplace = useCallback((data: Record<string, unknown>) => {
-    setTransformerParams(prev => replaceConfigPart(prev, data))
+    setTransformerParams((prev) => {
+      const next = replaceConfigPart(prev, data)
+      if (next !== prev) {
+        hasUserEditedRef.current = true
+      }
+      return next
+    })
   }, [])
 
   const handleWidgetReplace = useCallback((data: Record<string, unknown>) => {
-    setWidgetParams(prev => replaceConfigPart(prev, data))
+    setWidgetParams((prev) => {
+      const next = replaceConfigPart(prev, data)
+      if (next !== prev) {
+        hasUserEditedRef.current = true
+      }
+      return next
+    })
   }, [])
 
   // Handle save
@@ -162,6 +212,12 @@ export function WidgetConfigForm({
       const success = await onSave(currentConfig)
       if (!success) {
         setError(t('form.saveError'))
+      } else {
+        hasUserEditedRef.current = false
+        if (debounceRef.current) {
+          clearTimeout(debounceRef.current)
+          debounceRef.current = null
+        }
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : t('form.unknownError'))
@@ -190,7 +246,7 @@ export function WidgetConfigForm({
       <div className="space-y-4 p-4 border-b">
         <LocalizedInput
           value={title}
-          onChange={setTitle}
+          onChange={handleTitleChange}
           placeholder={t('form.titlePlaceholder')}
           languages={languages}
           defaultLang={defaultLang}
@@ -199,7 +255,7 @@ export function WidgetConfigForm({
 
         <LocalizedInput
           value={description}
-          onChange={setDescription}
+          onChange={handleDescriptionChange}
           placeholder={t('form.descriptionPlaceholder')}
           languages={languages}
           defaultLang={defaultLang}

--- a/src/niamoto/gui/ui/src/components/widgets/WidgetPreviewPanel.tsx
+++ b/src/niamoto/gui/ui/src/components/widgets/WidgetPreviewPanel.tsx
@@ -280,7 +280,7 @@ export function WidgetPreviewPanel({
           orientation: 'v',
           x_axis: 'labels',
           y_axis: 'counts',
-          gradient_color: '#10b981',
+          gradient_color: '#4f8068',
           gradient_mode: 'luminance',
           show_legend: false,
         }
@@ -324,9 +324,9 @@ export function WidgetPreviewPanel({
           source: 'coordinates',
           type: 'circle_markers',
           style: {
-            color: '#1fb99d',
+            color: '#5f8f82',
             weight: 1,
-            fillColor: '#00716b',
+            fillColor: '#4f8068',
             fillOpacity: 0.5,
             radius: 8,
           },

--- a/src/niamoto/gui/ui/src/components/widgets/recipe/ColorMapEditor.tsx
+++ b/src/niamoto/gui/ui/src/components/widgets/recipe/ColorMapEditor.tsx
@@ -93,7 +93,7 @@ export function ColorMapEditor({ value, onChange, placeholder }: ColorMapEditorP
     const newEntry: ColorEntry = {
       id: nextId++,
       key: `serie${entries.length + 1}`,
-      color: '#1fb99d',
+      color: '#4f8068',
     }
     emitChange([...entries, newEntry])
   }, [entries, emitChange])

--- a/src/niamoto/gui/ui/src/components/widgets/recipe/RecipeEditor.tsx
+++ b/src/niamoto/gui/ui/src/components/widgets/recipe/RecipeEditor.tsx
@@ -1166,7 +1166,7 @@ export function RecipeEditor({ groupBy, onSave, initialRecipe }: RecipeEditorPro
                                     <Input
                                       type="color"
                                       className="h-8 w-12 p-1"
-                                      value={String(widgetParams[key] ?? param.default ?? '#1fb99d')}
+                                      value={String(widgetParams[key] ?? param.default ?? '#4f8068')}
                                       onChange={(e) => updateWidgetParam(key, e.target.value)}
                                     />
                                     <Input

--- a/src/niamoto/gui/ui/src/components/widgets/useWidgetConfig.test.tsx
+++ b/src/niamoto/gui/ui/src/components/widgets/useWidgetConfig.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+
+import { act, useEffect, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  type UseWidgetConfigReturn,
+  useWidgetConfig,
+} from './useWidgetConfig'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+}
+
+async function flushQueries() {
+  for (let index = 0; index < 5; index += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  }
+}
+
+describe('useWidgetConfig', () => {
+  let container: HTMLDivElement | null = null
+  let root: Root | null = null
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+    }
+    container?.remove()
+    container = null
+    root = null
+    vi.unstubAllGlobals()
+  })
+
+  function renderWithClient(ui: ReactNode) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+      )
+    })
+  }
+
+  it('rolls back transform duplication when export creation fails', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/config/transform' && !init) {
+        return Promise.resolve(
+          jsonResponse({
+            content: [
+              {
+                group_by: 'taxons',
+                widgets_data: {
+                  richness: {
+                    plugin: 'field_aggregator',
+                    params: { field: 'id' },
+                  },
+                },
+              },
+            ],
+          })
+        )
+      }
+
+      if (url === '/api/config/export' && !init) {
+        return Promise.resolve(
+          jsonResponse({
+            content: {
+              exports: [
+                {
+                  name: 'web_pages',
+                  exporter: 'html_page_exporter',
+                  groups: [
+                    {
+                      group_by: 'taxons',
+                      widgets: [
+                        {
+                          plugin: 'bar_plot',
+                          data_source: 'richness',
+                          title: { fr: 'Richesse', en: 'Richness' },
+                          description: { fr: "Nombre d'espèces", en: 'Species count' },
+                          params: { x_axis: 'name' },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          })
+        )
+      }
+
+      if (
+        url === '/api/config/transform/taxons/widgets/richness_copy' &&
+        init?.method === 'PUT'
+      ) {
+        return Promise.resolve(jsonResponse({ success: true }))
+      }
+
+      if (
+        url === '/api/config/export/taxons/widgets/richness_copy' &&
+        init?.method === 'PUT'
+      ) {
+        return Promise.resolve(jsonResponse({ detail: 'Export failed' }, { status: 500 }))
+      }
+
+      if (
+        url === '/api/config/transform/taxons/widgets/richness_copy' &&
+        init?.method === 'DELETE'
+      ) {
+        return Promise.resolve(jsonResponse({ success: true }))
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    let hook: UseWidgetConfigReturn | null = null
+    function Probe() {
+      const value = useWidgetConfig('taxons')
+      useEffect(() => {
+        hook = value
+      }, [value])
+      return null
+    }
+
+    renderWithClient(<Probe />)
+    await flushQueries()
+
+    expect(hook?.configuredWidgets).toHaveLength(1)
+
+    let duplicated = true
+    await act(async () => {
+      duplicated = await hook!.duplicateWidget('richness', 'richness_copy')
+    })
+
+    expect(duplicated).toBe(false)
+
+    const exportCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        url === '/api/config/export/taxons/widgets/richness_copy' &&
+        init?.method === 'PUT',
+    )
+    expect(exportCall).toBeDefined()
+    expect(JSON.parse(exportCall?.[1]?.body as string).title).toEqual({
+      fr: 'Richesse (copie)',
+      en: 'Richness (copie)',
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/config/transform/taxons/widgets/richness_copy',
+      { method: 'DELETE' },
+    )
+  })
+})

--- a/src/niamoto/gui/ui/src/components/widgets/useWidgetConfig.ts
+++ b/src/niamoto/gui/ui/src/components/widgets/useWidgetConfig.ts
@@ -8,7 +8,7 @@
  */
 import { useMemo, useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import type { LocalizedString } from '@/components/ui/localized-input'
+import type { LocalizedString } from '@/components/ui/localized-string'
 
 const API_BASE = '/api/config'
 
@@ -62,6 +62,16 @@ function getExportWidgetId(groupBy: string, widget: ExportWidgetConfig): string 
   if (widget.data_source) return widget.data_source
   if (widget.plugin === 'hierarchical_nav_widget') return getNavigationWidgetId(groupBy)
   return null
+}
+
+function appendCopySuffix(title: LocalizedString): LocalizedString {
+  if (typeof title === 'string') {
+    return `${title} (copie)`
+  }
+
+  return Object.fromEntries(
+    Object.entries(title).map(([lang, value]) => [lang, `${value} (copie)`]),
+  )
 }
 
 interface ExportGroupConfig {
@@ -387,23 +397,31 @@ async function performDuplicate(
     throw new Error(errorData.detail || 'Failed to create transform config')
   }
 
-  const exportRes = await fetch(
-    `${API_BASE}/export/${groupBy}/widgets/${newId}`,
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        plugin: sourceWidget.widgetPlugin,
-        data_source: newId,
-        title: `${sourceWidget.title} (copie)`,
-        description: sourceWidget.description,
-        params: { ...sourceWidget.widgetParams }
-      })
+  try {
+    const exportRes = await fetch(
+      `${API_BASE}/export/${groupBy}/widgets/${newId}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          plugin: sourceWidget.widgetPlugin,
+          data_source: newId,
+          title: appendCopySuffix(sourceWidget.title),
+          description: sourceWidget.description,
+          params: { ...sourceWidget.widgetParams }
+        })
+      }
+    )
+    if (!exportRes.ok) {
+      const errorData = await exportRes.json().catch(() => ({}))
+      throw new Error(errorData.detail || 'Failed to create export config')
     }
-  )
-  if (!exportRes.ok) {
-    const errorData = await exportRes.json().catch(() => ({}))
-    throw new Error(errorData.detail || 'Failed to create export config')
+  } catch (error) {
+    await fetch(
+      `${API_BASE}/transform/${groupBy}/widgets/${newId}`,
+      { method: 'DELETE' },
+    ).catch(() => undefined)
+    throw error
   }
 }
 

--- a/src/niamoto/gui/ui/src/i18n/locales/en/widgets.json
+++ b/src/niamoto/gui/ui/src/i18n/locales/en/widgets.json
@@ -398,7 +398,6 @@
     "previews": "Previews",
     "hidePreviews": "Hide previews",
     "showPreviews": "Show previews",
-    "performanceModeLow": "Performance mode",
     "refresh": "Refresh",
     "save": "Save",
     "saving": "Saving...",
@@ -421,7 +420,6 @@
     "previewDisabled": "Preview disabled",
     "previewOnDemand": "Hover to preview",
     "previewMode": {
-      "auto": "Auto",
       "thumbnail": "Thumbnails",
       "focused": "Focused",
       "off": "Off"

--- a/src/niamoto/gui/ui/src/i18n/locales/fr/widgets.json
+++ b/src/niamoto/gui/ui/src/i18n/locales/fr/widgets.json
@@ -398,7 +398,6 @@
     "previews": "Aperçus",
     "hidePreviews": "Masquer les previews",
     "showPreviews": "Afficher les previews",
-    "performanceModeLow": "Mode performance",
     "refresh": "Actualiser",
     "save": "Sauvegarder",
     "saving": "Sauvegarde...",
@@ -421,7 +420,6 @@
     "previewDisabled": "Preview désactivée",
     "previewOnDemand": "Survolez pour prévisualiser",
     "previewMode": {
-      "auto": "Automatique",
       "thumbnail": "Miniatures",
       "focused": "Ciblé",
       "off": "Désactivé"

--- a/tests/core/plugins/widgets/test_bar_plot.py
+++ b/tests/core/plugins/widgets/test_bar_plot.py
@@ -53,6 +53,7 @@ class TestBarPlotWidget(NiamotoTestCase):
         self.assertNotIn("<p class='error'>", result)
         self.assertNotIn("<p class='info'>", result)
         self.assertIn("plotly-graph-div", result)
+        self.assertIn("#4f8068", result)
 
     def test_render_basic_dataframe_avoids_plotly_express(self):
         """Simple single-trace charts should use the faster graph_objects path."""

--- a/tests/core/plugins/widgets/test_donut_chart.py
+++ b/tests/core/plugins/widgets/test_donut_chart.py
@@ -6,6 +6,7 @@ from niamoto.core.plugins.widgets.donut_chart import (
     DonutChartParams,
     SubplotConfig,
 )
+from niamoto.core.plugins.widgets.plotly_utils import MUTED_CHART_COLORS
 from tests.common.base_test import NiamotoTestCase
 
 
@@ -55,6 +56,7 @@ class TestDonutChartWidget(NiamotoTestCase):
         self.assertNotIn("<p class='error'>", result)
         self.assertIn("plotly-chart-widget", result)
         self.assertIn("donut-chart-widget", result)
+        self.assertIn(MUTED_CHART_COLORS[0], result)
 
     def test_render_dataframe_missing_columns(self):
         """Test DataFrame with missing required columns."""

--- a/tests/core/plugins/widgets/test_plotly_utils.py
+++ b/tests/core/plugins/widgets/test_plotly_utils.py
@@ -43,6 +43,13 @@ def test_generate_muted_discrete_colors_extends_palette_without_duplicates():
     assert all(color.startswith("#") and len(color) == 7 for color in colors)
 
 
+def test_generate_muted_discrete_colors_keeps_large_palettes_unique():
+    colors = generate_muted_discrete_colors(len(MUTED_CHART_COLORS) * 12)
+
+    assert len(colors) == len(set(colors))
+    assert all(color.startswith("#") and len(color) == 7 for color in colors)
+
+
 def test_generate_muted_gradient_colors_softens_multi_color_gradient():
     colors = generate_muted_gradient_colors("#ff6b35", 4, "saturation")
 

--- a/tests/core/plugins/widgets/test_plotly_utils.py
+++ b/tests/core/plugins/widgets/test_plotly_utils.py
@@ -1,6 +1,12 @@
 from unittest.mock import Mock
 
-from niamoto.core.plugins.widgets.plotly_utils import render_plotly_figure
+from niamoto.core.plugins.widgets.plotly_utils import (
+    MUTED_CHART_COLORS,
+    generate_muted_discrete_colors,
+    generate_muted_gradient_colors,
+    get_plotly_layout_defaults,
+    render_plotly_figure,
+)
 from tests.common.base_test import NiamotoTestCase
 
 
@@ -21,3 +27,26 @@ class TestRenderPlotlyFigure(NiamotoTestCase):
 
         self.assertIn("plotConfig.responsive = false;", html)
         self.assertIn("plotConfig.staticPlot = true;", html)
+
+
+def test_layout_defaults_use_muted_colorway():
+    defaults = get_plotly_layout_defaults()
+
+    assert defaults["colorway"] == MUTED_CHART_COLORS
+
+
+def test_generate_muted_discrete_colors_extends_palette_without_duplicates():
+    colors = generate_muted_discrete_colors(len(MUTED_CHART_COLORS) + 3)
+
+    assert colors[: len(MUTED_CHART_COLORS)] == MUTED_CHART_COLORS
+    assert len(colors) == len(set(colors))
+    assert all(color.startswith("#") and len(color) == 7 for color in colors)
+
+
+def test_generate_muted_gradient_colors_softens_multi_color_gradient():
+    colors = generate_muted_gradient_colors("#ff6b35", 4, "saturation")
+
+    assert len(colors) == 4
+    assert colors[0] != "#ff6b35"
+    assert len(set(colors)) == 4
+    assert all(color.startswith("#") and len(color) == 7 for color in colors)

--- a/tests/core/plugins/widgets/test_radial_gauge.py
+++ b/tests/core/plugins/widgets/test_radial_gauge.py
@@ -282,6 +282,8 @@ class TestRadialGaugeWidget(NiamotoTestCase):
         self.assertIsInstance(result, str)
         self.assertNotIn("<p class='error'>", result)
         self.assertIn("plotly-graph-div", result)
+        self.assertIn("#b76f63", result)
+        self.assertNotIn("#f02828", result)
 
     def test_render_with_deprecated_units(self):
         """Test rendering with deprecated units parameter."""
@@ -726,7 +728,7 @@ class TestRadialGaugeParams(NiamotoTestCase):
         self.assertIsNone(params.unit)
         self.assertIsNone(params.steps)
         self.assertIsNone(params.threshold)
-        self.assertEqual(params.bar_color, "cornflowerblue")
+        self.assertEqual(params.bar_color, "#6d8796")
         self.assertEqual(params.background_color, "white")
         self.assertEqual(params.gauge_shape, "angular")
         self.assertEqual(params.style_mode, "classic")

--- a/tests/gui/api/routers/test_config_api_exports.py
+++ b/tests/gui/api/routers/test_config_api_exports.py
@@ -66,6 +66,75 @@ def test_update_export_widget_preserves_layout_and_accepts_localized_metadata(
     assert widget["template"] == "custom.html"
 
 
+def test_update_export_widget_can_clear_metadata(gui_duckdb_client, gui_duckdb_context):
+    export_path = gui_duckdb_context / "config" / "export.yml"
+    export_path.write_text(
+        yaml.safe_dump(
+            {
+                "exports": [
+                    {
+                        "name": "web_pages",
+                        "exporter": "html_page_exporter",
+                        "groups": [
+                            {
+                                "group_by": "taxons",
+                                "widgets": [
+                                    {
+                                        "plugin": "bar_plot",
+                                        "data_source": "richness",
+                                        "title": {"fr": "Richesse", "en": "Richness"},
+                                        "description": {
+                                            "fr": "Description",
+                                            "en": "Description",
+                                        },
+                                        "params": {"x_axis": "name"},
+                                        "layout": {"order": 3, "colspan": 2},
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    response = gui_duckdb_client.put(
+        "/api/config/export/taxons/widgets/richness",
+        json={
+            "plugin": "bar_plot",
+            "data_source": "richness",
+            "params": {"x_axis": "name"},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    saved = yaml.safe_load(export_path.read_text(encoding="utf-8"))
+    widget = saved["exports"][0]["groups"][0]["widgets"][0]
+    assert widget["title"] == {"fr": "Richesse", "en": "Richness"}
+    assert widget["description"] == {"fr": "Description", "en": "Description"}
+
+    response = gui_duckdb_client.put(
+        "/api/config/export/taxons/widgets/richness",
+        json={
+            "plugin": "bar_plot",
+            "data_source": "richness",
+            "title": None,
+            "description": None,
+            "params": {"x_axis": "name"},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    saved = yaml.safe_load(export_path.read_text(encoding="utf-8"))
+    widget = saved["exports"][0]["groups"][0]["widgets"][0]
+    assert "title" not in widget
+    assert "description" not in widget
+    assert widget["layout"] == {"order": 3, "colspan": 2}
+
+
 def test_api_export_suggestions_route_serializes_response(monkeypatch):
     monkeypatch.setattr(
         config_router,

--- a/tests/gui/api/routers/test_config_api_exports.py
+++ b/tests/gui/api/routers/test_config_api_exports.py
@@ -1,11 +1,69 @@
 from unittest.mock import Mock
 
 import pytest
+import yaml
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from niamoto.gui.api.app import create_app
 from niamoto.gui.api.routers import config as config_router
+
+
+def test_update_export_widget_preserves_layout_and_accepts_localized_metadata(
+    gui_duckdb_client, gui_duckdb_context
+):
+    export_path = gui_duckdb_context / "config" / "export.yml"
+    export_path.write_text(
+        yaml.safe_dump(
+            {
+                "exports": [
+                    {
+                        "name": "web_pages",
+                        "exporter": "html_page_exporter",
+                        "groups": [
+                            {
+                                "group_by": "taxons",
+                                "widgets": [
+                                    {
+                                        "plugin": "bar_plot",
+                                        "data_source": "richness",
+                                        "title": "Richness",
+                                        "params": {"x_axis": "name"},
+                                        "layout": {"order": 3, "colspan": 2},
+                                        "template": "custom.html",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    response = gui_duckdb_client.put(
+        "/api/config/export/taxons/widgets/richness",
+        json={
+            "plugin": "donut_chart",
+            "data_source": "richness",
+            "title": {"fr": "Richesse", "en": "Richness"},
+            "description": {"fr": "Description", "en": "Description"},
+            "params": {"value_field": "count"},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+
+    saved = yaml.safe_load(export_path.read_text(encoding="utf-8"))
+    widget = saved["exports"][0]["groups"][0]["widgets"][0]
+    assert widget["plugin"] == "donut_chart"
+    assert widget["title"] == {"fr": "Richesse", "en": "Richness"}
+    assert widget["description"] == {"fr": "Description", "en": "Description"}
+    assert widget["params"] == {"value_field": "count"}
+    assert widget["layout"] == {"order": 3, "colspan": 2}
+    assert widget["template"] == "custom.html"
 
 
 def test_api_export_suggestions_route_serializes_response(monkeypatch):

--- a/tests/gui/api/routers/test_layout.py
+++ b/tests/gui/api/routers/test_layout.py
@@ -21,6 +21,59 @@ from niamoto.gui.api.app import create_app
 INSTANCE_DIR = Path(__file__).parents[4] / "test-instance" / "niamoto-nc"
 
 
+def test_layout_accepts_localized_widget_metadata(
+    gui_duckdb_client, gui_duckdb_context
+):
+    export_path = gui_duckdb_context / "config" / "export.yml"
+    export_path.write_text(
+        yaml.safe_dump(
+            {
+                "exports": [
+                    {
+                        "name": "web_pages",
+                        "exporter": "html_page_exporter",
+                        "groups": [
+                            {
+                                "group_by": "taxons",
+                                "widgets": [
+                                    {
+                                        "plugin": "bar_plot",
+                                        "data_source": "richness",
+                                        "title": {
+                                            "fr": "Richesse spécifique",
+                                            "en": "Species richness",
+                                        },
+                                        "description": {
+                                            "fr": "Nombre d'espèces",
+                                            "en": "Number of species",
+                                        },
+                                        "layout": {"order": 0, "colspan": 2},
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    response = gui_duckdb_client.get("/api/layout/taxons")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["widgets"][0]["title"] == {
+        "fr": "Richesse spécifique",
+        "en": "Species richness",
+    }
+    assert payload["widgets"][0]["description"] == {
+        "fr": "Nombre d'espèces",
+        "en": "Number of species",
+    }
+
+
 class TestLayoutPreviewDelegation:
     """Vérifie que layout.preview_widget utilise le moteur de preview unifié."""
 

--- a/tests/gui/api/services/preview_engine/test_engine.py
+++ b/tests/gui/api/services/preview_engine/test_engine.py
@@ -1,5 +1,8 @@
 """Tests for preview engine transformer execution paths and caching."""
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -257,6 +260,36 @@ def test_open_db_returns_same_instance():
     assert db1 is db2
     MockDB.assert_called_once()
     assert MockDB.call_args.kwargs.get("read_only") is None
+
+
+def test_render_serializes_concurrent_preview_work():
+    engine = _make_engine()
+    request = PreviewRequest(template_id="configured_widget", group_by="taxons")
+    active = 0
+    max_active = 0
+    active_lock = threading.Lock()
+
+    def render_standard(*args, **kwargs):
+        nonlocal active, max_active
+        with active_lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.05)
+        with active_lock:
+            active -= 1
+        return "<div>ok</div>"
+
+    with (
+        patch.object(engine, "_open_db", return_value=MagicMock()),
+        patch.object(engine, "_get_transformer_service", return_value=MagicMock()),
+        patch.object(engine, "_render_standard", side_effect=render_standard),
+        patch.object(engine, "_wrap_html", side_effect=lambda html, **kwargs: html),
+    ):
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(executor.map(lambda _: engine.render(request), range(4)))
+
+    assert [result.html for result in results] == ["<div>ok</div>"] * 4
+    assert max_active == 1
 
 
 def test_open_db_creates_new_after_invalidate():

--- a/tests/gui/api/services/templates/utils/test_widget_utils.py
+++ b/tests/gui/api/services/templates/utils/test_widget_utils.py
@@ -70,6 +70,7 @@ def test_generate_widget_params_for_binned_distribution_uses_transform_labels():
     assert params["x_axis"] == "bin"
     assert params["y_axis"] == "count"
     assert params["labels"] == {"bin": "DBH class", "count": "Trees"}
+    assert params["gradient_color"] == "#4f8068"
 
 
 def test_generate_widget_params_for_series_extractor_respects_overrides():


### PR DESCRIPTION
## Summary
- preserve widget layout and localized metadata in collection block config updates
- prevent unchanged widget forms from becoming dirty and retriggering previews
- soften generated widget colors and serialize backend preview rendering to avoid DuckDB attach races

## Tests
- uv run pytest tests/core/plugins/widgets/test_bar_plot.py tests/core/plugins/widgets/test_bar_plot_auto_color.py tests/core/plugins/widgets/test_donut_chart.py tests/core/plugins/widgets/test_radial_gauge.py tests/core/plugins/widgets/test_plotly_utils.py tests/gui/api/services/templates/utils/test_widget_utils.py tests/gui/api/services/templates/utils/test_class_object_rendering.py tests/gui/api/services/preview_engine/test_engine.py tests/gui/api/routers/test_preview.py tests/gui/api/routers/test_layout.py
- pnpm run build